### PR TITLE
Feat/notification: 알림 목록 조회 및 읽음 확인 API 구현

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/Global/enums/ErrorCode.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/Global/enums/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
 	DUPLICATE_PET(HttpStatus.CONFLICT,"이미 등록된 반려동물입니다."),
 	USER_FAILED_SAVE(HttpStatus.INTERNAL_SERVER_ERROR, "유저 저장에 실패했습니다."),
 	USER_FAILED_DELETE(HttpStatus.INTERNAL_SERVER_ERROR, "유저 삭제에 실패했습니다."),
-	USER_FAILED_ADJUST(HttpStatus.INTERNAL_SERVER_ERROR, "유저 수정에 실패했습니다.");
+	USER_FAILED_ADJUST(HttpStatus.INTERNAL_SERVER_ERROR, "유저 수정에 실패했습니다."),
+	NOTI_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알립입니다.");
 	private final HttpStatus errorCode;
 	private final String message;
 

--- a/src/main/java/com/daengdaeng_eodiga/project/Global/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/Global/exception/NotificationNotFoundException.java
@@ -1,0 +1,9 @@
+package com.daengdaeng_eodiga.project.Global.exception;
+
+import com.daengdaeng_eodiga.project.Global.enums.ErrorCode;
+
+public class NotificationNotFoundException extends BusinessException {
+	public NotificationNotFoundException() {
+		super(ErrorCode.NOTI_NOT_FOUND.getErrorCode(), ErrorCode.NOTI_NOT_FOUND.getMessage());
+	}
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/notification/controller/NotificationController.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/notification/controller/NotificationController.java
@@ -1,0 +1,32 @@
+package com.daengdaeng_eodiga.project.notification.controller;
+
+import com.daengdaeng_eodiga.project.Global.Security.config.CustomOAuth2User;
+import com.daengdaeng_eodiga.project.Global.dto.ApiResponse;
+import com.daengdaeng_eodiga.project.notification.dto.NotiResponseDto;
+import com.daengdaeng_eodiga.project.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NotiResponseDto>>> fetchUnreadNotifications(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        int userId = customOAuth2User.getUserDTO().getUserid();
+        List<NotiResponseDto> response = notificationService.fetchUnreadNotifications(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{notificationId}")
+    public ResponseEntity<ApiResponse<String>> updateNotificationAsRead(@PathVariable int notificationId) {
+        notificationService.updateNotificationAsRead(notificationId);
+        return ResponseEntity.ok(ApiResponse.success("notification read successfully"));
+    }
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/notification/dto/NotiResponseDto.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/notification/dto/NotiResponseDto.java
@@ -1,0 +1,24 @@
+package com.daengdaeng_eodiga.project.notification.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NotiResponseDto {
+    private int notificationId;
+    private String eventType;
+    private String content;
+    private String createdDate;
+    private String createdTime;
+
+    @Builder
+    public NotiResponseDto(int notificationId, String eventType, String content, String createdDate, String createdTime) {
+        this.notificationId = notificationId;
+        this.eventType = eventType;
+        this.content = content;
+        this.createdDate = createdDate;
+        this.createdTime = createdTime;
+    }
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/notification/entity/Notification.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/notification/entity/Notification.java
@@ -1,0 +1,30 @@
+package com.daengdaeng_eodiga.project.notification.entity;
+
+import com.daengdaeng_eodiga.project.Global.entity.BaseEntity;
+import com.daengdaeng_eodiga.project.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "notification")
+public class Notification extends BaseEntity {
+    @Id
+    @Column(name = "notification_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int notificationId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private String type;
+
+    private String content;
+
+    @ColumnDefault("false")
+    private boolean reading;
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/notification/repository/NotificationRepository.java
@@ -1,0 +1,11 @@
+package com.daengdaeng_eodiga.project.notification.repository;
+
+import com.daengdaeng_eodiga.project.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Integer> {
+    List<Notification> findByUser_UserIdAndReadingFalse(int userId);
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/notification/repository/NotificationRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Integer> {
-    List<Notification> findByUser_UserIdAndReadingFalse(int userId);
+    List<Notification> findByUser_UserIdAndReadingFalseOrderByCreatedAtDesc(int userId);
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/notification/service/NotificationService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/notification/service/NotificationService.java
@@ -21,7 +21,7 @@ public class NotificationService {
 
     public List<NotiResponseDto> fetchUnreadNotifications(int userId) {
 
-        List<Notification> unreadNotifications = notificationRepository.findByUser_UserIdAndReadingFalse(userId);
+        List<Notification> unreadNotifications = notificationRepository.findByUser_UserIdAndReadingFalseOrderByCreatedAtDesc(userId);
         List<NotiResponseDto> notificationDtos = unreadNotifications.stream()
                 .map(notification -> NotiResponseDto.builder()
                         .notificationId(notification.getNotificationId())

--- a/src/main/java/com/daengdaeng_eodiga/project/notification/service/NotificationService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/notification/service/NotificationService.java
@@ -1,0 +1,43 @@
+package com.daengdaeng_eodiga.project.notification.service;
+
+import com.daengdaeng_eodiga.project.Global.exception.NotificationNotFoundException;
+import com.daengdaeng_eodiga.project.common.service.CommonCodeService;
+import com.daengdaeng_eodiga.project.notification.dto.NotiResponseDto;
+import com.daengdaeng_eodiga.project.notification.entity.Notification;
+import com.daengdaeng_eodiga.project.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+    private final CommonCodeService commonCodeService;
+
+    public List<NotiResponseDto> fetchUnreadNotifications(int userId) {
+
+        List<Notification> unreadNotifications = notificationRepository.findByUser_UserIdAndReadingFalse(userId);
+        List<NotiResponseDto> notificationDtos = unreadNotifications.stream()
+                .map(notification -> NotiResponseDto.builder()
+                        .notificationId(notification.getNotificationId())
+                        .eventType(commonCodeService.getCommonCodeName(notification.getType()))
+                        .content(notification.getContent())
+                        .createdDate(notification.getCreatedAt().toLocalDate().toString())
+                        .createdTime(notification.getCreatedAt().toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm")))
+                        .build())
+                .collect(Collectors.toList());
+
+        return notificationDtos;
+    }
+
+    public void updateNotificationAsRead(int notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(NotificationNotFoundException::new);
+        notification.setReading(true);
+    }
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/pet/service/PetService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/pet/service/PetService.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.daengdaeng_eodiga.project.Global.exception.*;
-import com.daengdaeng_eodiga.project.common.repository.CommonCodeRepository;
 import com.daengdaeng_eodiga.project.common.service.CommonCodeService;
 import com.daengdaeng_eodiga.project.pet.dto.PetDetailResponseDto;
 import com.daengdaeng_eodiga.project.pet.dto.PetListResponseDto;


### PR DESCRIPTION
## ✏️ 작업 내용
> - 알림 목록 조회
> 1. 로그인한 유저에 대한 알림을 조회하도록 한다.
> 2. 알림은 사용자가 확인하지 않은 알림만 조회되도록 한다. (reading 필드가 false인 데이터만 조회)
> 3. 알림 목록은 최신순으로 정렬된다.
> 4. 알림타입은 "방문 예정 등록" 타입과 "즐겨찾기 이벤트" 타입으로 나뉜다.

> - 알림 읽음 확인
> 1. 특정 알림의 reading 필드를 true로 변경한다.

### 스크린샷 
아직 테스트를 못해봐서 아래는 예상 response 화면입니다.
- 알림 목록 조회 
![image](https://github.com/user-attachments/assets/dcf9217d-9de9-4019-b924-b19dfc290022)

- 알림 읽음 확인
![image](https://github.com/user-attachments/assets/d222731a-174b-4e2a-94ce-e38798b0937b)


## 💬 리뷰 요구사항
