### PR TITLE
Refactor/favorite: 즐겨찾기 중복등록 예외 수정

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/favorite/repository/FavoriteRepository.java
@@ -1,7 +1,6 @@
 package com.daengdaeng_eodiga.project.favorite.repository;
 
 import com.daengdaeng_eodiga.project.favorite.entity.Favorite;
-import com.daengdaeng_eodiga.project.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,5 +11,5 @@ import java.util.List;
 @Repository
 public interface FavoriteRepository extends JpaRepository<Favorite, Integer> {
     Page<Favorite> findByUser_UserIdOrderByUpdatedAtDesc(int userId, Pageable pageable);
-    List<Favorite> findByUser(User user);
+    List<Favorite> findByUser_UserIdAndPlace_PlaceId(int userId, int placeId);
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/favorite/service/FavoriteService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/favorite/service/FavoriteService.java
@@ -28,7 +28,10 @@ public class FavoriteService {
 
     public FavoriteResponseDto registerFavorite(int userId, FavoriteRequestDto favoriteRequestDto) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-        if( !favoriteRepository.findByUser(user).isEmpty() ) { throw new DuplicateFavoriteException(); }
+        int placeId = favoriteRequestDto.getPlaceId();
+        if ( !favoriteRepository.findByUser_UserIdAndPlace_PlaceId(userId, placeId).isEmpty() ) {
+            throw new DuplicateFavoriteException();
+        }
 
         Place place = placeRepository.findById(favoriteRequestDto.getPlaceId()).orElseThrow(PlaceNotFoundException::new);
 

--- a/src/main/java/com/daengdaeng_eodiga/project/pet/service/PetService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/pet/service/PetService.java
@@ -22,9 +22,11 @@ import com.daengdaeng_eodiga.project.pet.repository.PetRepository;
 import com.daengdaeng_eodiga.project.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class PetService {
 	private final PetRepository petRepository;
 	private final UserRepository userRepository;


### PR DESCRIPTION
## ✏️ 작업 내용
> ### 즐겨찾기 중복 등록 시 예외를 수정했습니다.

> * 변경전 : 특정 사용자에 대한 즐겨찾기 데이터가 존재하면 중복 예외 throw
> * 변경후 : 특정 사용자의 특정 장소에 대한 즐겨찾기 데이터가 존재하면 중복 예외 throw

### 스크린샷 
> ![image](https://github.com/user-attachments/assets/43e3ceed-76c8-47da-b6cc-43160f40afdf)


## 💬 리뷰 요구사항
