### PR TITLE
Feat/banner: 이벤트 이미지 길이 수정 및 레포지토리 수정

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/event/entity/Event.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/event/entity/Event.java
@@ -20,7 +20,7 @@ public class Event extends BaseEntity {
     @Column(name = "event_name")
     private String eventName;
 
-    @Column(name = "event_image")
+    @Column(name = "event_image", length = 500)
     private String eventImage;
 
     @Column(name = "event_description", length = 500)

--- a/src/main/java/com/daengdaeng_eodiga/project/event/repository/EventRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/event/repository/EventRepository.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Integer> {
-
-    @Query("SELECT e FROM Event e WHERE :today BETWEEN e.startDate AND e.endDate")
+    @Query("SELECT e FROM Event e WHERE :today <= e.endDate")
     List<Event> findActiveEvents(@Param("today") LocalDate today);
 }


### PR DESCRIPTION
## ✏️ 작업 내용
> * 이벤트 이미지 길이 : 250에서 500으로 수정
> * 이벤트 레포지토리 : 
> 이벤트 진행기간에만 조회되도록 -> 이벤트 종료전까지는 다 조회되도록 수정

### 스크린샷 
> 


## 💬 리뷰 요구사항