### PR TITLE
Feat/이미지가져오기오류수정

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
@@ -63,19 +63,20 @@ SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.long
        o.start_time, o.end_time,
        COUNT(f.favorite_id) AS favorite_count,
        ps.score AS place_score,
-       GROUP_CONCAT(pm.path) AS imageurl
+       (SELECT pm.path FROM place_media pm WHERE pm.place_id = p.place_id LIMIT 1) AS imageurl
 FROM place p
 LEFT JOIN favorite f ON p.place_id = f.place_id
 LEFT JOIN opening_date o ON o.place_id = p.place_id
 LEFT JOIN common_code c ON p.place_type = c.code_id
 LEFT JOIN place_score ps ON p.place_id = ps.place_id
-LEFT JOIN place_media pm ON pm.place_id = p.place_id
 GROUP BY p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude,
          p.street_addresses, p.tel_number, p.url, c.name, p.description,
          p.parking, p.indoor, p.outdoor, o.start_time, o.end_time, ps.score
 ORDER BY favorite_count DESC
-LIMIT 3;""", nativeQuery = true)
+LIMIT 3;
+""", nativeQuery = true)
     List<Object[]> findTopFavoritePlaces();
+
 
 
 


### PR DESCRIPTION
1. topfavorite api에서 leftjoin된 테이블들에 해당 장소에대한 정보가 2개이상 들어가있을때 이미지 url을 다중으로 불러오는 오류수정