### PR TITLE
Refactor/story: 쿼리문에서 DATE() 제거

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/story/repository/StoryRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/story/repository/StoryRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface StoryRepository extends JpaRepository<Story, Integer> {
     Optional<Story> findByStoryId(int storyId);
 
-    @Query("SELECT COUNT(s) FROM Story s WHERE DATE(s.createdAt) = CURRENT_DATE")
+    @Query("SELECT COUNT(s) FROM Story s WHERE s.createdAt >= CURRENT_DATE")
     long countByTodayCreated();
 
     @Query("SELECT s.user.nickname, s.storyId, s.city, s.cityDetail, s.path " +

--- a/src/main/java/com/daengdaeng_eodiga/project/story/repository/StoryRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/story/repository/StoryRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface StoryRepository extends JpaRepository<Story, Integer> {
     Optional<Story> findByStoryId(int storyId);
 
-    @Query("SELECT COUNT(s) FROM Story s WHERE s.createdAt >= CURRENT_DATE")
+    @Query("SELECT COUNT(s) FROM Story s WHERE s.createdAt >= CURRENT_DATE AND s.createdAt < CURRENT_DATE + 1")
     long countByTodayCreated();
 
     @Query("SELECT s.user.nickname, s.storyId, s.city, s.cityDetail, s.path " +


### PR DESCRIPTION
# 📄 PR 변경사항
- **오늘 날짜에 해당하는 스토리 개수를 조회**하는 쿼리문을 수정했습니다.
- mysql에서만 동작하는 date()함수를 제거하고 current_date(날짜+00:00:00시)와 createdAt(날짜+nn:nn:nn시)의 크기를 비교하도록 수정하였습니다.
- 오늘 0시보다는 크거나 같고, 내일 0시보다는 작도록 수정했습니다.

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
![image](https://github.com/user-attachments/assets/54999715-8147-4ab5-8370-a0171ef93127)


# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [x] 주석 및 print를 제거하셨나요?
- [x] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?

