### PR TITLE
Refactor/story: 오늘 날짜 기준 스토리 업로드 개수 조회하는 쿼리문 수정

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/story/repository/StoryRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/story/repository/StoryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,8 +14,9 @@ import java.util.Optional;
 public interface StoryRepository extends JpaRepository<Story, Integer> {
     Optional<Story> findByStoryId(int storyId);
 
-    @Query("SELECT COUNT(s) FROM Story s WHERE s.createdAt >= CURRENT_DATE AND s.createdAt < CURRENT_DATE + 1")
-    long countByTodayCreated();
+    @Query("SELECT COUNT(s) FROM Story s WHERE s.createdAt BETWEEN :todayStart AND :tomorrowStart")
+    long countByTodayCreated(@Param("todayStart") LocalDateTime todayStart,
+                             @Param("tomorrowStart") LocalDateTime  tomorrowStart);
 
     @Query("SELECT s.user.nickname, s.storyId, s.city, s.cityDetail, s.path " +
             "FROM Story s " +

--- a/src/main/java/com/daengdaeng_eodiga/project/story/service/StoryService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/story/service/StoryService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -69,7 +70,9 @@ public class StoryService {
      * @param storyRequestDto
      */
     public void registerStory(int userId, StoryRequestDto storyRequestDto){
-        if( storyRepository.countByTodayCreated() == 10 ) {
+        if( storyRepository.countByTodayCreated(
+                LocalDate.now().atStartOfDay(),
+                LocalDate.now().plusDays(1).atStartOfDay()) == 10 ) {
             throw new DailyStoryUploadLimitException();
         }
         if( regionOwnerLogRepository.findByUserIdAndCityAndCityDetail(


### PR DESCRIPTION
# 📄 PR 변경사항
- 오늘 날짜 기준 스토리 업로드 개수 조회하는 쿼리문 수정

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
기존의 CURRENT+1을 인식하지 못해서, 직접 오늘날짜와 내일날짜를 입력받아 조회했습니다.
### 레포지토리
![image](https://github.com/user-attachments/assets/ac0c951c-7c49-42bc-b5ec-1ff7f61134d1)
### 조회 후, 예외발생하는 서비스 코드
![image](https://github.com/user-attachments/assets/e1b242bd-4f9f-465c-adde-231adc1754ca)


# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [x] 주석 및 print를 제거하셨나요?
- [x] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?

