### PR TITLE
Feat/review register bug fix

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/review/dto/ReviewRegisterRequest.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/review/dto/ReviewRegisterRequest.java
@@ -24,6 +24,8 @@ public record ReviewRegisterRequest(
 	@NotNull(message = "방문 날짜는 필수입니다.")
 	LocalDate visitedAt,
 	Set<Integer> pets,
-	@NotNull(message = "리뷰 타입은 필수입니다.")
-	String reviewType ) {
+
+	String reviewType
+	)
+{
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/review/service/ReviewService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/review/service/ReviewService.java
@@ -75,18 +75,22 @@ public class ReviewService {
 	}
 
 	private Review createAndSaveReview(ReviewRegisterRequest request, User user, Place place) {
-		commonCodeService.isCommonCode(request.reviewType());
+		String reviewType = (request.reviewType() != null) ? request.reviewType() : "REVIEW_TYP_01";
+
+		commonCodeService.isCommonCode(reviewType);
+
 		Review review = Review.builder()
 				.score(request.score())
 				.content(request.content())
 				.user(user)
 				.place(place)
 				.visitedAt(request.visitedAt())
-				.reviewtype(request.reviewType())
+				.reviewtype(reviewType)
 				.build();
 
 		return reviewRepository.save(review);
 	}
+
 
 	private List<ReviewPet> saveReviewPetsIfPresent(Review review, List<Pet> pets) {
 		return pets == null || pets.isEmpty() ? List.of() : reviewPetService.saveReviewPet(review, pets);


### PR DESCRIPTION
# 📄 PR 변경사항
-  일반리뷰 등록시 reviewtype이 null 로 들어가는데, 이때 예외처리가 고쳐지지 않는점 수정

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
-  reviewtype이 null일때 자동으로 REVIEW_TYP_01이 들어가게 변경
- 실시간리뷰 판별 api에서 200ok를 통해 리뷰를 작성하게될때 프론트단에서 REVIEW_TYP_02를 던지게되고 이때 그것을 저장

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 일반리뷰
![image](https://github.com/user-attachments/assets/e52b3898-cd02-4665-bcee-d61b35c3320e)
-실시간리뷰
![image](https://github.com/user-attachments/assets/1854722f-acd6-4b55-b72a-3615771b6b4c)

# 확인
- [x] 주석 및 print를 제거하셨나요?
- [x] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?

