### PR TITLE
refeat : 실시간 리뷰 삭제시, 방문 횟수 감소, 순위 변경시 알림 전달

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/region/entity/RegionVisitDay.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/region/entity/RegionVisitDay.java
@@ -43,4 +43,7 @@ public class RegionVisitDay extends BaseEntity {
 		this.count +=1;
 	}
 
+	public void decrementCount() {
+		this.count -=1;
+	}
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/region/entity/RegionVisitTotal.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/region/entity/RegionVisitTotal.java
@@ -42,5 +42,8 @@ public class RegionVisitTotal extends BaseEntity {
 	public void addCount() {
 		this.count +=1;
 	}
+	public void decrementCount() {
+		this.count -=1;
+	}
 
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/region/repository/RegionOwnerLogRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/region/repository/RegionOwnerLogRepository.java
@@ -56,5 +56,20 @@ public interface RegionOwnerLogRepository  extends JpaRepository<RegionOwnerLog,
 		" WHERE r.city = :city AND r.cityDetail = :cityDetail "
 		+ "order by r.count desc limit 1")
 	Optional<RegionOwnerLog> findRegionOwnerByCityAndCityDetail(String city, String cityDetail);
+
+	@Query("  SELECT r "+
+		" FROM RegionOwnerLog r " +
+		" WHERE r.city = :city AND r.cityDetail = :cityDetail "
+		+ "order by r.count desc limit 2")
+	List<RegionOwnerLog> findTop2RegionOwnerByCityAndCityDetail(String city, String cityDetail);
+
+	@Query("SELECT r " +
+		"FROM RegionOwnerLog r " +
+		"WHERE r.user.userId = :userId " +
+		"AND r.city = :city " +
+		"AND r.cityDetail = :cityDetail "
+		+ "order by r.createdAt desc limit 1 "
+	)
+	Optional<RegionOwnerLog> findTop1UserRegionOwnerLogAtCreated(int userId,String city, String cityDetail);
 }
 

--- a/src/main/java/com/daengdaeng_eodiga/project/region/repository/RegionVisitDayRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/region/repository/RegionVisitDayRepository.java
@@ -11,6 +11,6 @@ import com.daengdaeng_eodiga.project.user.entity.User;
 
 public interface RegionVisitDayRepository extends JpaRepository<RegionVisitDay, Integer> {
 
-	@Query("SELECT r FROM RegionVisitDay r WHERE r.city = :city AND r.cityDetail = :cityDetail AND r.user = :user AND r.createdAt >= :startedAt AND r.createdAt <= :endedAt")
+	@Query("SELECT r FROM RegionVisitDay r WHERE r.city = :city AND r.cityDetail = :cityDetail AND r.user = :user AND r.createdAt >= :startedAt AND r.createdAt < :endedAt")
 	Optional<RegionVisitDay> findByCityAndCityDetailAndUserAndCreatedAt(String city,String cityDetail, User user, LocalDateTime startedAt, LocalDateTime endedAt);
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/review/service/ReviewService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/review/service/ReviewService.java
@@ -147,7 +147,12 @@ public class ReviewService {
 
 
 	public void deleteReview(int reviewId) {
-		reviewRepository.deleteById(reviewId);
+		reviewRepository.findById(reviewId).ifPresent(review -> {
+			reviewRepository.delete(review);
+			if(review.getReviewtype().equals("REVIEW_TYP_02")) {
+				regionService.decrementCountVisitRegionForDB(review.getPlace().getCity(), review.getPlace().getCityDetail(), review.getUser(), review.getCreatedAt().toLocalDate());
+			}
+		});
 	}
 
 	public ReviewsResponse fetchPlaceReviews(int placeId, int page, int size, OrderType orderType) {


### PR DESCRIPTION
# 📄 PR 변경사항
- 실시간 리뷰 삭제시, 땅 주인에도 반영

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
- 실시간 리뷰가 삭제되면, 'Region_visit_day' 테이블과, 'Region_visit_total'테이블에서 방문횟수를 감소시킨다.
- 만약 방문 횟수가 감소됨으로써 땅 주인이 변경된다면, 기존 땅 주인이었던 유저와 새로 땅 주인이된 유저에게 알림을 전달한다.

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 매번 삭제할때마다 'Region_visit_day' 테이블과, 'Region_visit_total 테이블을 update하고, Region_owner_log 테이블을 삭제해야 한다. 트랜잭션이 오래 묶여있고, 쓰기 락이 3번 걸림으로써 조회에 부담이 생김. 개선할 수 있는 방법이 있는지 찾아보는 것이 좋을 것 같습니다.


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 
<img width="925" alt="image" src="https://github.com/user-attachments/assets/575cd4d3-f41b-4994-8def-fe6979a306d4" />
<img width="590" alt="image" src="https://github.com/user-attachments/assets/3fd27a64-97fd-4437-8636-edc95f027c1d" />


# 확인
- [x] 주석 및 print를 제거하셨나요?
- [x] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?

