### PR TITLE
feat: 가까운순불러오기 api n+1문제 해결

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/place/dto/PlaceDtoMapper.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/dto/PlaceDtoMapper.java
@@ -26,7 +26,7 @@ public class PlaceDtoMapper {
             dto.setIndoor(result[13] != null && parseBoolean(result[13]));
             dto.setOutdoor(result[14] != null && parseBoolean(result[14]));
             dto.setDistance(result.length > 15 && result[15] != null ? ((Number) result[15]).doubleValue() : null);
-            dto.setIsFavorite(result.length > 16 && result[16] != null && parseIntegerToBoolean(result[16]));
+            dto.setIsFavorite(result.length > 16 && result[16] != null && parseBoolean(result[16]));
             dto.setStartTime(result.length > 17 && result[17] != null ? result[17].toString() : null);
             dto.setEndTime(result.length > 18 && result[18] != null ? result[18].toString() : null);
             dto.setFavoriteCount(result.length > 19 && result[19] != null ? ((Number) result[19]).intValue() : 0);

--- a/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
@@ -104,13 +104,15 @@ LIMIT 3;
 """, nativeQuery = true)
     List<Object[]> findTopScoredPlacesWithinRadius(@Param("latitude") Double latitude, @Param("longitude") Double longitude);
 
+
+
     @Query(value = """
 SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude,
        p.street_addresses, p.tel_number, p.url, c.name AS place_type, p.description,
        p.parking, p.indoor, p.outdoor,
        (6371 * acos(cos(radians(:latitude)) * cos(radians(p.latitude)) *
        cos(radians(p.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(p.latitude)))) AS distance,
-       CASE WHEN EXISTS (SELECT 1 FROM favorite f WHERE f.place_id = p.place_id) THEN 1 ELSE 0 END AS is_favorite,
+       CASE WHEN f.user_id = :userId THEN 1 ELSE 0 END AS is_favorite,
        o.start_time, o.end_time,
        (SELECT COUNT(*) FROM favorite f WHERE f.place_id = p.place_id) AS favorite_count,
        ps.score AS place_score,
@@ -120,10 +122,12 @@ LEFT JOIN opening_date o ON p.place_id = o.place_id
 LEFT JOIN common_code c ON p.place_type = c.code_id
 LEFT JOIN place_score ps ON p.place_id = ps.place_id
 LEFT JOIN place_media pm ON pm.place_id = p.place_id
+LEFT JOIN favorite f ON f.place_id = p.place_id AND f.user_id = :userId
 ORDER BY distance ASC
 LIMIT 30;
 """, nativeQuery = true)
-    List<Object[]> findNearestPlaces(@Param("latitude") Double latitude, @Param("longitude") Double longitude);
+    List<Object[]> findNearestPlaces(@Param("latitude") Double latitude, @Param("longitude") Double longitude, @Param("userId") Integer userId);
+
 
 
     @Query(value = """

--- a/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
@@ -112,13 +112,9 @@ public class PlaceService {
     }
 
     public List<PlaceDto> getNearestPlaces(Double latitude, Double longitude, Integer userId) {
-        List<Object[]> results = placeRepository.findNearestPlaces(latitude, longitude);
+        List<Object[]> results = placeRepository.findNearestPlaces(latitude, longitude, userId);
         return results.stream()
-                .map(row -> {
-                    PlaceDto dto = PlaceDtoMapper.convertToPlaceDto(row);
-                    dto.setIsFavorite(userId != null && checkIfUserFavoritedPlace(dto.getPlaceId(), userId));
-                    return dto;
-                })
+                .map(PlaceDtoMapper::convertToPlaceDto)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
# 📄 PR 변경사항
-  가까운순 30개 불러오기 api n+1문제 해

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
- checkIfUserFavoritedPlace 메서드가 장소하나당 한번 호출되어 n+1오류가 발생하였는데, 쿼리문에 left join을 추가하여 쿼리문에서 즐겨찾기 여부를 불러오도록 수정

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
###수정전
![image](https://github.com/user-attachments/assets/948b13e1-9587-4245-aa16-ecc92024e87b)
###수정후
![image](https://github.com/user-attachments/assets/d9040873-0552-477d-989a-bd30621baf07)


# 확인
- [x] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?

