### PR TITLE
refactor/region :  땅 주인 조회시, 유저에게 펫이 없다면 null로 전달

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/region/service/RegionService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/region/service/RegionService.java
@@ -67,8 +67,11 @@ public class RegionService {
 			cityDetailByRegionOwnerLogIds.put(roi.getId(),roi.getCityDetail());
 			regionOwnerCityDetails.put(roi.getId(),new RegionOwnerCityDetail(roi.getUserId(),roi.getUserNickname(),roi.getCount(),null));
 			List<PetResponse> pets = petsByRegionOwnerLogIds.getOrDefault(roi.getId(),new ArrayList<>());
-			pets.add(new PetResponse(roi.getPetId(),roi.getPetName(),roi.getPetImage()));
-			petsByRegionOwnerLogIds.put(roi.getId(),pets);
+			if(roi.getPetId() != null) {
+				pets.add(new PetResponse(roi.getPetId(),roi.getPetName(),roi.getPetImage()));
+				petsByRegionOwnerLogIds.put(roi.getId(),pets);
+			}
+
 		});
 		regionOwnerLogIdsByCity.forEach((city,ids) ->{
 			HashMap<String,RegionOwnerCityDetail> regionOwnerCities = new HashMap<>();


### PR DESCRIPTION
# 📄 PR 변경사항
- 땅 주인 조회시, 펫이 없다면 null로 전달

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
- 땅 주인을 조회하는데 펫 정보도 같이 조회해 전달하는 로직이 있었는데, 펫이 없을 때의 경우를 예외처리 하지 않아서 nullException 발생했었습니다. 예외처리를 통해 펫이 없다면 null을 전달합니다.

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
<img width="945" alt="image" src="https://github.com/user-attachments/assets/24a216bd-a773-404c-969a-f29eb258dd60" />


# 확인
- [x] 주석 및 print를 제거하셨나요?
- [x] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?

