### PR TITLE
Refactor/story: 스토리 확인 후 전체스토리 조회 시 정렬깨짐 문제 해결중

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/story/entity/Story.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/story/entity/Story.java
@@ -31,7 +31,7 @@ public class Story {
     @Column(name = "city_detail")
     private String cityDetail;
 
-    @Column(name = "path")
+    @Column(name = "path", length = 700)
     private String path;
 
     @Column(name = "created_at")

--- a/src/main/java/com/daengdaeng_eodiga/project/story/repository/StoryRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/story/repository/StoryRepository.java
@@ -117,7 +117,8 @@ ORDER BY
     CASE
         WHEN fs.story_type = 'viewed' THEN fs.latest_story_viewed_at
         ELSE NULL
-    END ASC
+    END ASC,
+    fs.landOwnerId
 """, nativeQuery = true)
     List<Object[]> findMainPriorityStories(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/story/repository/StoryRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/story/repository/StoryRepository.java
@@ -37,32 +37,25 @@ public interface StoryRepository extends JpaRepository<Story, Integer> {
                                                   @Param("cityDetail") String cityDetail);
 
 @Query(value = """
-WITH RecentStory AS (
+WITH StoryStatus AS (
     SELECT
-        s.story_id,
         s.user_id AS landOwnerId,
         s.city,
         s.city_detail,
-        s.created_at,
-        s.end_at
-    FROM
-        story s
-    WHERE
-        s.end_at > NOW()
-        AND s.user_id != :userId
-),
-StoryStatus AS (
-    SELECT
-        rs.*,
         sv.created_at AS story_viewed_at,
         CASE
             WHEN sv.story_id IS NOT NULL THEN 'viewed'
             ELSE 'unviewed'
-        END AS story_type
+        END AS story_type,
+        s.created_at AS group_created_at
     FROM
-        RecentStory rs
+        story s
     LEFT JOIN
-        story_view sv ON rs.story_id = sv.story_id AND sv.user_id = :userId
+        story_view sv
+        ON s.story_id = sv.story_id AND sv.user_id = :userId
+    WHERE
+        s.end_at > NOW()
+        AND s.user_id != :userId
 ),
 GroupedStoryStatus AS (
     SELECT
@@ -73,52 +66,46 @@ GroupedStoryStatus AS (
             WHEN COUNT(CASE WHEN story_type = 'unviewed' THEN 1 END) = 0 THEN 'viewed'
             ELSE 'unviewed'
         END AS group_story_type,
-        MIN(created_at) AS group_created_at,
+        MIN(group_created_at) AS group_created_at,
         MAX(CASE WHEN story_type = 'viewed' THEN story_viewed_at ELSE NULL END) AS latest_story_viewed_at
     FROM
         StoryStatus
     GROUP BY
         landOwnerId, city, city_detail
-),
-FinalStories AS (
-    SELECT
-        gss.landOwnerId,
-        gss.city,
-        gss.city_detail,
-        gss.group_story_type AS story_type,
-        gss.group_created_at,
-        gss.latest_story_viewed_at,
-        (SELECT p.image FROM pet p WHERE p.user_id = gss.landOwnerId ORDER BY p.pet_id ASC LIMIT 1) AS petImage
-    FROM
-        GroupedStoryStatus gss
+    ORDER BY
+        CASE
+            WHEN COUNT(CASE WHEN story_type = 'unviewed' THEN 1 END) = 0 THEN 2
+            ELSE 1
+        END,
+        MIN(group_created_at) DESC,
+        MAX(CASE WHEN story_type = 'viewed' THEN story_viewed_at ELSE NULL END) ASC
 )
 SELECT DISTINCT
-    fs.landOwnerId,
+    gss.landOwnerId,
     u.nickname,
-    fs.city,
-    fs.city_detail,
-    fs.petImage,
-    fs.story_type,
-    fs.group_created_at,
-    fs.latest_story_viewed_at
+    gss.city,
+    gss.city_detail,
+    (SELECT p.image FROM pet p WHERE p.user_id = gss.landOwnerId ORDER BY p.pet_id ASC LIMIT 1) AS petImage,
+    gss.group_story_type AS story_type,
+    gss.group_created_at,
+    gss.latest_story_viewed_at
 FROM
-    FinalStories fs
+    GroupedStoryStatus gss
 JOIN
-    users u ON fs.landOwnerId = u.user_id
+    users u ON gss.landOwnerId = u.user_id
 ORDER BY
     CASE
-        WHEN fs.story_type = 'unviewed' THEN 1
-        WHEN fs.story_type = 'viewed' THEN 2
+        WHEN gss.group_story_type = 'unviewed' THEN 1
+        WHEN gss.group_story_type = 'viewed' THEN 2
     END,
     CASE
-        WHEN fs.story_type = 'unviewed' THEN fs.group_created_at
+        WHEN gss.group_story_type = 'unviewed' THEN gss.group_created_at
         ELSE NULL
     END DESC,
     CASE
-        WHEN fs.story_type = 'viewed' THEN fs.latest_story_viewed_at
+        WHEN gss.group_story_type = 'viewed' THEN gss.latest_story_viewed_at
         ELSE NULL
-    END ASC,
-    fs.landOwnerId
+    END ASC;
 """, nativeQuery = true)
     List<Object[]> findMainPriorityStories(@Param("userId") Integer userId);
 }


### PR DESCRIPTION
# 📄 PR 변경사항
> - 변경 전 쿼리문 실행계획
![image](https://github.com/user-attachments/assets/80118127-1f3e-4bd7-b342-7afac113e3c7)

> ### 변경사항
> 1. 임시 테이블 2개 (RecentStory, FinalStories)를 없애고 각각 left join과 join을 이용하여 임시테이블 사용을 줄임
> 2. 마지막에 order by를 하는데, 중간테이블에서도 order by를 해주어 순서가 깨지지 않도록 하였음
> 3. 스토리 확인 테이블의 user_id, story_id, created_at을 묶어 인덱스를 추가하여 filesort로 생기는 null값에 대한 정렬깨짐을 막으려고 함

> - 변경 후 쿼리문 실행계획
![image](https://github.com/user-attachments/assets/755d1d49-646f-4562-92bd-245cfc8dbf1c)
> 효율적이지 않은 filesort가 발생하는 이유는 컬럼값중 viewed인지 unviewed인지에 따라 정렬기준이 달라야 하기때문에 case문을 통과하는 과정에서 전체 데이터들을 스캔하기 때문

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->



# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [x] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?

