### PR TITLE
Feat/resize img : 장소 저장 API 구현, 프론트 테스트 서버 CORS 허용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 
+	//Thumbnailator
+	implementation 'net.coobird:thumbnailator:0.4.20'
+
 
 }
 

--- a/src/main/java/com/daengdaeng_eodiga/project/Global/S3/service/S3Uploader.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/Global/S3/service/S3Uploader.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Date;
 import java.util.HashMap;
@@ -19,6 +20,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.daengdaeng_eodiga.project.Global.S3.enums.S3Prefix;
 
 @Component
@@ -53,6 +56,22 @@ public class S3Uploader {
 		);
 
 		return generatePresignedUrlRequest;
+	}
+
+	/**
+	 * S3에 이미지 업로드
+	 *
+	 * @author 김가은
+	 *
+	 * */
+
+	public String putObject(String filePath,String fileName, InputStream inputStream, ObjectMetadata metadata) {
+		String key = filePath + "/" + fileName;
+
+		PutObjectRequest request = new PutObjectRequest(bucket, key,inputStream, metadata)
+			.withCannedAcl(CannedAccessControlList.PublicRead);
+		amazonS3.putObject(request);
+		return amazonS3.getUrl(bucket, key).toString();
 	}
 
 	private Date getPresignedUrlExpiration() {

--- a/src/main/java/com/daengdaeng_eodiga/project/Global/Security/config/SecurityConfig.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/Global/Security/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
     public CorsConfiguration corsConfiguration() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowCredentials(true);
-        configuration.setAllowedOrigins(Arrays.asList("https://localhost:5173","https://pet.daengdaeng-where.link","https://daengdaeng-where-git-test-wldusdns-projects.vercel.app"));
+        configuration.setAllowedOrigins(Arrays.asList("https://localhost:5173","https://pet.daengdaeng-where.link","https://daengdaeng-where-git-test-wldusdns-projects.vercel.app","https://fronttest.daengdaeng-where.link"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Origin", "Content-Type", "Accept", "Set-Cookie","Access-Control-Allow-Origin"));
         configuration.setExposedHeaders(List.of("Set-Cookie","Access-Control-Allow-Origin"));

--- a/src/main/java/com/daengdaeng_eodiga/project/admin/AdminController.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/admin/AdminController.java
@@ -1,0 +1,55 @@
+package com.daengdaeng_eodiga.project.admin;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.daengdaeng_eodiga.project.Global.dto.ApiResponse;
+import com.daengdaeng_eodiga.project.admin.dto.PlaceRegister;
+import com.daengdaeng_eodiga.project.admin.service.AdminService;
+import com.daengdaeng_eodiga.project.place.entity.Place;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v2/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+	private final AdminService adminService;
+
+	/**
+	 * 애견 동반 가능한 장소를 등록
+	 *
+	 * @author 김가은
+	 * @return Place : 등록된 장소 정보
+	 *
+	 * */
+	@PostMapping("/place")
+	public ResponseEntity<ApiResponse<Place>>  savePlace(@RequestBody PlaceRegister request) {
+		Place response = adminService.savePlace(request);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	/**
+	 * 애견 동반 가능한 장소 이미지 업로드
+	 *
+	 * 이미지를 받아, 원본 이미지와 썸네일용 이미지를 리사이징해서 따로 S3에 업로드
+	 *
+	 * @author 김가은
+	 * @return Map<String,String> : 원본 이미지 경로, 썸네일 이미지 경로
+	 * */
+	@PostMapping("/placeImage")
+	public ResponseEntity<ApiResponse<Map<String,String>>> resizeImage(@RequestParam("image") MultipartFile file) throws IOException {
+		Map<String,String> response = adminService.uploadPlaceImage(file);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/admin/dto/PlaceRegister.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/admin/dto/PlaceRegister.java
@@ -33,4 +33,10 @@ public class PlaceRegister {
 	private String thumbImgPath;
 
 	private String imgPath;
+
+	private Double latitude;
+
+	private Double longitude;
+
+	private String townShip;
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/admin/dto/PlaceRegister.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/admin/dto/PlaceRegister.java
@@ -1,0 +1,36 @@
+package com.daengdaeng_eodiga.project.admin.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PlaceRegister {
+	private String name;
+
+	private String city;
+
+	private String cityDetail;
+
+	private String postCode;
+
+	private String streetAddresses;
+
+	private String telNumber;
+
+	private String url;
+
+	private String placeType;
+
+	private String description;
+
+	private String weightLimit;
+
+	private Boolean parking;
+
+	private Boolean indoor;
+
+	private Boolean outdoor;
+
+	private String thumbImgPath;
+
+	private String imgPath;
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/admin/service/AdminService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/admin/service/AdminService.java
@@ -61,6 +61,9 @@ public class AdminService {
 			.indoor(placeRegister.getIndoor())
 			.outdoor(placeRegister.getOutdoor())
 			.thumbImgPath(placeRegister.getThumbImgPath())
+			.latitude(placeRegister.getLatitude())
+			.longitude(placeRegister.getLongitude())
+			.township(placeRegister.getTownShip())
 			.build();
 		Place savedPlace = placeService.savePlace(place);
 		placeService.savePlaceMedia(savedPlace, placeRegister.getImgPath());

--- a/src/main/java/com/daengdaeng_eodiga/project/admin/service/AdminService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/admin/service/AdminService.java
@@ -1,0 +1,153 @@
+package com.daengdaeng_eodiga.project.admin.service;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import net.coobird.thumbnailator.Thumbnails;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.daengdaeng_eodiga.project.Global.S3.service.S3Uploader;
+import com.daengdaeng_eodiga.project.Global.exception.NotFoundException;
+import com.daengdaeng_eodiga.project.admin.dto.PlaceRegister;
+import com.daengdaeng_eodiga.project.common.service.CommonCodeService;
+import com.daengdaeng_eodiga.project.place.entity.Place;
+import com.daengdaeng_eodiga.project.place.service.PlaceService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminService {
+
+	private final CommonCodeService commonCodeService;
+	private final PlaceService placeService;
+	private final S3Uploader s3Uploader;
+
+	/**
+	 * 애견 동반 가능한 장소를 등록
+	 *
+	 * @author 김가은
+	 * @return Place : 등록된 장소 정보
+	 *
+	 * */
+
+	public Place savePlace(PlaceRegister placeRegister) {
+		commonCodeService.isCommonCode(placeRegister.getPlaceType());
+
+		Place place = Place.builder()
+			.name(placeRegister.getName())
+			.city(placeRegister.getCity())
+			.cityDetail(placeRegister.getCityDetail())
+			.postCode(placeRegister.getPostCode())
+			.streetAddresses(placeRegister.getStreetAddresses())
+			.telNumber(placeRegister.getTelNumber())
+			.url(placeRegister.getUrl())
+			.placeType(placeRegister.getPlaceType())
+			.description(placeRegister.getDescription())
+			.weightLimit(placeRegister.getWeightLimit())
+			.parking(placeRegister.getParking())
+			.indoor(placeRegister.getIndoor())
+			.outdoor(placeRegister.getOutdoor())
+			.thumbImgPath(placeRegister.getThumbImgPath())
+			.build();
+		Place savedPlace = placeService.savePlace(place);
+		placeService.savePlaceMedia(savedPlace, placeRegister.getImgPath());
+		return savedPlace;
+
+	}
+
+	/**
+	 * 애견 동반 가능한 장소 이미지 업로드
+	 *
+	 * 이미지를 받아, 원본 이미지와 썸네일용 이미지를 리사이징해서 따로 S3에 업로드
+	 *
+	 * @author 김가은
+	 * @return Map<String,String> : 원본 이미지 경로, 썸네일 이미지 경로
+	 * */
+
+	public HashMap<String,String> uploadPlaceImage(MultipartFile img) throws IOException {
+		String imgPath = uploadImage(img);
+		String thumbImgPath = uploadThumbImg(img);
+		HashMap<String,String> paths = new HashMap<>();
+		paths.put("imgPath", imgPath);
+		paths.put("thumbImgPath", thumbImgPath);
+		return paths;
+	}
+
+	/**
+	 * 원본 이미지 업로드
+	 *
+	 * @author 김가은
+	 * @return String : 이미지 경로
+	 * */
+
+	public String uploadImage(MultipartFile img) throws IOException {
+
+
+		String originalFilename = img.getOriginalFilename();
+
+		ObjectMetadata metadata = new ObjectMetadata();
+		metadata.setContentLength(img.getSize());
+		metadata.setContentType(img.getContentType());
+		return s3Uploader.putObject("PLACE",originalFilename,img.getInputStream(), metadata);
+	}
+
+	/**
+	 * 원본 이미지 썸네일용으로 리사이징해서 업로드
+	 *
+	 * @author 김가은
+	 * @return String : 이미지 경로
+	 * */
+
+
+	private String uploadThumbImg(MultipartFile img) throws IOException {
+		BufferedImage bufferedImage = ImageIO.read(img.getInputStream());
+		String originalFilename = img.getOriginalFilename();
+		int width = bufferedImage.getWidth();
+		int height = bufferedImage.getHeight();
+
+		if(width > 108 || height > 130) {
+			BufferedImage resizedImage= Thumbnails.of(bufferedImage)
+				.size(108, 130)
+				.asBufferedImage();
+
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			ImageIO.write(resizedImage, getFileExtension(img.getOriginalFilename()), outputStream);
+			byte[] resizedImageBytes = outputStream.toByteArray();
+			ByteArrayInputStream inputStream = new ByteArrayInputStream(resizedImageBytes);
+
+			ObjectMetadata thumbMetadata = new ObjectMetadata();
+			thumbMetadata.setContentLength(resizedImageBytes.length);
+			thumbMetadata.setContentType(img.getContentType());
+			return s3Uploader.putObject("THUMB", originalFilename,inputStream, thumbMetadata);
+		}
+		return null;
+	}
+
+	/**
+	 * 이미지 확장자 추출
+	 *
+	 * @author 김가은
+	 * @return String : 이미지 확장자
+	 * */
+
+	public String getFileExtension(String fileName) {
+		if (fileName == null || fileName.isEmpty() || !fileName.contains(".")) {
+			throw new NotFoundException("파일 확장자",fileName);
+		}
+		return fileName.substring(fileName.lastIndexOf(".") + 1);
+	}
+
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/place/entity/Place.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/entity/Place.java
@@ -4,6 +4,7 @@ import com.daengdaeng_eodiga.project.Global.entity.BaseEntity;
 import com.daengdaeng_eodiga.project.favorite.entity.Favorite;
 import com.daengdaeng_eodiga.project.review.entity.Review;
 import com.daengdaeng_eodiga.project.visit.entity.Visit;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -19,6 +20,7 @@ import org.hibernate.annotations.OnDeleteAction;
 @Entity
 @Table(name = "Place")
 @Setter
+@JsonIgnoreProperties({"placeScores"})
 @NoArgsConstructor
 @AllArgsConstructor
 public class Place extends BaseEntity {
@@ -66,13 +68,18 @@ public class Place extends BaseEntity {
 
     private Boolean outdoor;
 
-    @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Column(name = "thumb_img_path",length = 700)
+    private String thumbImgPath;
+
+    @OneToMany(mappedBy = "place", orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Review> reviews = new ArrayList<>();
 
-    @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "place", orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Visit> visits = new ArrayList<>();
 
-    @OneToOne(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "place", cascade = CascadeType.PERSIST, orphanRemoval = true,optional = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private PlaceScore placeScores = new PlaceScore();
 
@@ -80,15 +87,28 @@ public class Place extends BaseEntity {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private List<OpeningDate> openingDates = new ArrayList<>();
 
-    @OneToOne(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    private ReviewSummary reviewSummaries = new ReviewSummary();
-
-    @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "place", orphanRemoval = true)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Favorite> favorite = new ArrayList<>();
 
-    @OneToOne(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    private PlaceMedia placeMedia = new PlaceMedia();
+    @Builder
+    public Place(String name, String city, String cityDetail, String township, Double latitude, Double longitude, String postCode, String streetAddresses, String telNumber, String url, String placeType, String description, String weightLimit, Boolean parking, Boolean indoor, Boolean outdoor, String thumbImgPath) {
+        this.name = name;
+        this.city = city;
+        this.cityDetail = cityDetail;
+        this.township = township;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.postCode = postCode;
+        this.streetAddresses = streetAddresses;
+        this.telNumber = telNumber;
+        this.url = url;
+        this.placeType = placeType;
+        this.description = description;
+        this.weightLimit = weightLimit;
+        this.parking = parking;
+        this.indoor = indoor;
+        this.outdoor = outdoor;
+        this.thumbImgPath = thumbImgPath;
+    }
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/place/entity/PlaceScore.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/entity/PlaceScore.java
@@ -6,8 +6,10 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Entity
 @NoArgsConstructor
 @Table(name = "Place_Score")
@@ -17,15 +19,15 @@ public class PlaceScore extends BaseEntity {
     @Column(name = "place_id")
     private int placeId;
 
-    @MapsId("placeId")
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "place_id", nullable = false, referencedColumnName = "place_id")
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "place_id", nullable = false)
     private Place place;
 
-    private Double score;
+    private Double score = 0.0;
 
     @Column(name = "review_count")
-    private int reviewCount;
+    private int reviewCount = 0;
 
     public void updateScore(int score) {
         this.score = (this.score * this.reviewCount + score) / (this.reviewCount + 1);
@@ -34,6 +36,7 @@ public class PlaceScore extends BaseEntity {
     @Builder
     public PlaceScore(Place place, Double score, int reviewCount) {
         this.place = place;
+        this.placeId = place.getPlaceId();
         this.score = score;
         this.reviewCount = reviewCount;
     }

--- a/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
@@ -5,7 +5,10 @@ import com.daengdaeng_eodiga.project.Global.exception.PlaceNotFoundException;
 import com.daengdaeng_eodiga.project.common.service.CommonCodeService;
 import com.daengdaeng_eodiga.project.place.dto.*;
 import com.daengdaeng_eodiga.project.place.entity.Place;
+import com.daengdaeng_eodiga.project.place.entity.PlaceMedia;
+import com.daengdaeng_eodiga.project.place.entity.PlaceScore;
 import com.daengdaeng_eodiga.project.place.entity.ReviewSummary;
+import com.daengdaeng_eodiga.project.place.repository.PlaceMediaRepository;
 import com.daengdaeng_eodiga.project.place.repository.PlaceRepository;
 import com.daengdaeng_eodiga.project.place.repository.PlaceScoreRepository;
 import com.daengdaeng_eodiga.project.preference.dto.UserRequsetPrefernceDto;
@@ -43,6 +46,7 @@ public class PlaceService {
     private final OpenAiService openAiService;
     private final CommonCodeService commonCodeService;
     private final RedisLocationRepository redisLocationRepository;
+    private final PlaceMediaRepository placeMediaRepository;
     private static final Logger logger = LoggerFactory.getLogger(PlaceService.class);
 
     public List<PlaceDto> filterPlaces(String city, String cityDetail, String placeTypeCode, Double latitude, Double longitude, Integer userId) {
@@ -372,5 +376,17 @@ public class PlaceService {
     private List<String> getRandomReviews(List<String> reviews, int limit) {
         Collections.shuffle(reviews);
         return reviews.subList(0, limit);
+    }
+
+    public Place savePlace(Place place) {
+        PlaceScore placeScore = new PlaceScore();
+        placeScore.setPlace(place);
+        place.setPlaceScores(placeScore);
+        Place savedPlace = placeRepository.save(place);
+        return savedPlace;
+    }
+    public void savePlaceMedia(Place place, String imagePath) {
+        PlaceMedia placeMedia = PlaceMedia.builder().place(place).path(imagePath).build();
+        placeMediaRepository.save(placeMedia);
     }
 }


### PR DESCRIPTION
# 📄 PR 변경사항
- 장소 저장 API 구현, 프론트 테스트 서버 CORS 허용

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
- 장소를 저장하면, 장소 이미지를 썸네일용으로 리사이징해서 원본과 함께 S3에 업로드한다.
- 장소 저장시, placeSocre 테이블에도 score 값도 저장되게 영속성 CASCADE PERSIST로 수정

# ✨개선 사항 및 참고 사항
- 썸네일용 이미지는 S3의 THUMB/ 디렉토리에 저장


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 
<img width="933" alt="image" src="https://github.com/user-attachments/assets/c3d2f7a9-7121-4597-87ef-3ebba4641e54" />


# 확인
- [x] 주석 및 print를 제거하셨나요?
- [x] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?

