### PR TITLE
풀텍스트서치 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,7 @@ dependencies {
 
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
-
 
 }
 

--- a/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
@@ -187,16 +187,21 @@ LEFT JOIN favorite f ON p.place_id = f.place_id AND f.user_id = :userId
 LEFT JOIN opening_date o ON o.place_id = p.place_id
 LEFT JOIN place_score ps ON ps.place_id = p.place_id
 LEFT JOIN place_media pm ON pm.place_id = p.place_id
-WHERE (:keyword IS NULL OR p.name LIKE CONCAT('%', :keyword, '%'))
+WHERE (:keyword IS NULL 
+       OR MATCH(p.name) AGAINST(:formattedKeyword IN BOOLEAN MODE) 
+       OR p.name LIKE CONCAT('%', :keyword, '%'))
 ORDER BY distance ASC
 LIMIT 30;
 """, nativeQuery = true)
     List<Object[]> findByKeywordAndLocation(
             @Param("keyword") String keyword,
+            @Param("formattedKeyword") String formattedKeyword,
             @Param("latitude") Double latitude,
             @Param("longitude") Double longitude,
             @Param("userId") Integer userId
     );
+
+
 
 
 

--- a/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
@@ -53,7 +53,12 @@ public class PlaceService {
 
     public List<PlaceDto> searchPlaces(String keyword, Double latitude, Double longitude, Integer userId) {
         Integer effectiveUserId = userId != null ? userId : -1;
-        List<Object[]> results = placeRepository.findByKeywordAndLocation(keyword, latitude, longitude, effectiveUserId);
+
+        String formattedKeyword = Arrays.stream(keyword.split("\\s+"))
+                .map(word -> word + "*")
+                .collect(Collectors.joining(" "));
+
+        List<Object[]> results = placeRepository.findByKeywordAndLocation(keyword, formattedKeyword, latitude, longitude, effectiveUserId);
         return results.stream().map(PlaceDtoMapper::convertToPlaceDto).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
# 📄 PR 변경사항
1. **PlaceRepository 수정**:
   - `findByKeywordAndLocation` 메서드에서 Full-Text Search와 LIKE 연산자를 함께 사용하여 검색 정확도 개선.
   - Full-Text Search로 부분 일치 검색을 수행하고, 누락된 짧은 단어는 LIKE 연산자로 보완.

2. **PlaceService 수정**:
   - `searchPlaces` 메서드에서 입력 키워드를 공백으로 분리하고 각 단어에 와일드카드를 추가하는 전처리 로직 추가.
   
# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
-  기존의 키워드를 포함하였는지 여부를 판별하는 메서드로 강 아지 와같은 검색어를 검색하면, 정확하게 "강 아지"를 포함한 장소를 검색하는 문제점이 있었음. 따라서 Full-Text search로 부분 일치 검색을 수행하고 누락된 단어는 LIKE연산자로 보완하여 이를 해결.

# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 입력: `"강 아지"`
- 결과:  강아지, 강, 아지를 포함한 검색결과 출력
![image](https://github.com/user-attachments/assets/1752c9d5-a94c-406f-af46-0faeb940bfba)




# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?

