### PR TITLE
Refactor/ place엔티티에 이미지 옮겨간것 api에 적용 및 조회  쿼리 개선

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
@@ -34,24 +34,24 @@ WHERE p.place_id = :placeId;
 
 
 
-    @Query(value =
-            "SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude, " +
-                    "p.post_code, p.street_addresses, p.tel_number, p.url, p.place_type, p.description, " +
-                    "p.weight_limit, p.parking, p.indoor, p.outdoor, " +
-                    "COALESCE(ps.score, 2) AS score, " +
-                    "GROUP_CONCAT(DISTINCT rk.keyword) AS keywords, " +
-                    "COUNT(DISTINCT r.review_id) AS review_count, " +
-                    "GROUP_CONCAT(DISTINCT pm.path) AS imageurl " +
-                    "FROM place p " +
-                    "LEFT JOIN review r ON p.place_id = r.place_id " +
-                    "LEFT JOIN review_keyword rk ON rk.review_id = r.review_id " +
-                    "LEFT JOIN place_score ps ON ps.place_id = p.place_id " +
-                    "LEFT JOIN place_media pm ON pm.place_id = p.place_id " +
-                    "GROUP BY p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude, " +
-                    "p.post_code, p.street_addresses, p.tel_number, p.url, p.place_type, p.description, " +
-                    "p.weight_limit, p.parking, p.indoor, p.outdoor, pm.path",
-            nativeQuery = true)
+    @Query(value = """
+SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude,
+       p.post_code, p.street_addresses, p.tel_number, p.url, p.place_type, p.description,
+       p.weight_limit, p.parking, p.indoor, p.outdoor,
+       COALESCE(ps.score, 2) AS score,
+       GROUP_CONCAT(DISTINCT rk.keyword) AS keywords,
+       COUNT(DISTINCT r.review_id) AS review_count,
+       p.thumb_img_path AS imageurl 
+FROM place p
+LEFT JOIN review r ON p.place_id = r.place_id
+LEFT JOIN review_keyword rk ON rk.review_id = r.review_id
+LEFT JOIN place_score ps ON ps.place_id = p.place_id
+GROUP BY p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude,
+         p.post_code, p.street_addresses, p.tel_number, p.url, p.place_type, p.description,
+         p.weight_limit, p.parking, p.indoor, p.outdoor, p.thumb_img_path
+""", nativeQuery = true)
     List<Object[]> findPlaceRecommendationsWithKeywords();
+
 
 
     @Query(value = """

--- a/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
@@ -21,15 +21,15 @@ SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.long
        CAST(o.end_time AS CHAR) AS end_time,
        (SELECT COUNT(*) FROM favorite f WHERE f.place_id = p.place_id) AS favorite_count,
        ps.score AS place_score,
-       pm.path AS imageurl
+       p.thumb_img_path AS imageurl
 FROM place p
 LEFT JOIN common_code c ON p.place_type = c.code_id
 LEFT JOIN opening_date o ON o.place_id = p.place_id
 LEFT JOIN place_score ps ON p.place_id = ps.place_id
-LEFT JOIN place_media pm ON pm.place_id = p.place_id
 WHERE p.place_id = :placeId;
 """, nativeQuery = true)
     List<Object[]> findPlaceDetailsById(@Param("placeId") int placeId);
+
 
 
 
@@ -58,12 +58,9 @@ WHERE p.place_id = :placeId;
 SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude,
        p.street_addresses, p.tel_number, p.url, c.name AS place_type, p.description,
        p.parking, p.indoor, p.outdoor,
-       NULL AS distance,
-       CASE WHEN EXISTS (SELECT 1 FROM favorite f WHERE f.place_id = p.place_id) THEN 1 ELSE 0 END AS is_favorite,
-       o.start_time, o.end_time,
        COUNT(f.favorite_id) AS favorite_count,
        ps.score AS place_score,
-       (SELECT pm.path FROM place_media pm WHERE pm.place_id = p.place_id LIMIT 1) AS imageurl
+       p.thumb_img_path AS imageurl
 FROM place p
 LEFT JOIN favorite f ON p.place_id = f.place_id
 LEFT JOIN opening_date o ON o.place_id = p.place_id
@@ -71,11 +68,12 @@ LEFT JOIN common_code c ON p.place_type = c.code_id
 LEFT JOIN place_score ps ON p.place_id = ps.place_id
 GROUP BY p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude,
          p.street_addresses, p.tel_number, p.url, c.name, p.description,
-         p.parking, p.indoor, p.outdoor, o.start_time, o.end_time, ps.score
+         p.parking, p.indoor, p.outdoor, ps.score, p.thumb_img_path
 ORDER BY favorite_count DESC
 LIMIT 3;
 """, nativeQuery = true)
     List<Object[]> findTopFavoritePlaces();
+
 
 
 
@@ -91,12 +89,11 @@ SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.long
        o.start_time, o.end_time,
        (SELECT COUNT(*) FROM favorite f WHERE f.place_id = p.place_id) AS favorite_count,
        ps.score AS place_score,
-       pm.path AS imageurl
+       p.thumb_img_path AS imageurl
 FROM place p
 LEFT JOIN place_score ps ON p.place_id = ps.place_id
 LEFT JOIN common_code c ON p.place_type = c.code_id
 LEFT JOIN opening_date o ON p.place_id = o.place_id
-LEFT JOIN place_media pm ON pm.place_id = p.place_id
 WHERE (6371 * acos(cos(radians(:latitude)) * cos(radians(p.latitude)) *
        cos(radians(p.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(p.latitude)))) <= 50
 ORDER BY ps.score DESC
@@ -107,26 +104,24 @@ LIMIT 3;
 
 
     @Query(value = """
-    SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude,
-           p.street_addresses, p.tel_number, p.url, c.name AS place_type, p.description,
-           p.parking, p.indoor, p.outdoor,
-           (6371 * acos(cos(radians(:latitude)) * cos(radians(p.latitude)) *
-           cos(radians(p.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(p.latitude)))) AS distance,
-           CASE WHEN f.user_id = :userId THEN 1 ELSE 0 END AS is_favorite,
-           o.start_time, o.end_time,
-           ps.score AS place_score,
-           pm.path AS imageurl
-    FROM place p
-    LEFT JOIN opening_date o ON p.place_id = o.place_id
-    LEFT JOIN common_code c ON p.place_type = c.code_id
-    LEFT JOIN place_score ps ON p.place_id = ps.place_id
-    LEFT JOIN place_media pm ON pm.place_id = p.place_id
-    LEFT JOIN favorite f ON f.place_id = p.place_id AND f.user_id = :userId
-    ORDER BY distance ASC
-    LIMIT 30;
-    """, nativeQuery = true)
+SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude,
+       p.street_addresses, p.tel_number, p.url, c.name AS place_type, p.description,
+       p.parking, p.indoor, p.outdoor,
+       (6371 * acos(cos(radians(:latitude)) * cos(radians(p.latitude)) *
+       cos(radians(p.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(p.latitude)))) AS distance,
+       CASE WHEN f.user_id = :userId THEN 1 ELSE 0 END AS is_favorite,
+       o.start_time, o.end_time,
+       ps.score AS place_score,
+       p.thumb_img_path AS imageurl
+FROM place p
+LEFT JOIN opening_date o ON p.place_id = o.place_id
+LEFT JOIN common_code c ON p.place_type = c.code_id
+LEFT JOIN place_score ps ON p.place_id = ps.place_id
+LEFT JOIN favorite f ON f.place_id = p.place_id AND f.user_id = :userId
+ORDER BY distance ASC
+LIMIT 30;
+""", nativeQuery = true)
     List<Object[]> findNearestPlaces(@Param("latitude") Double latitude, @Param("longitude") Double longitude, @Param("userId") Integer userId);
-
 
 
 
@@ -144,13 +139,12 @@ SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.long
        CAST(o.end_time AS CHAR) AS end_time,
        (SELECT COUNT(f2.favorite_id) FROM favorite f2 WHERE f2.place_id = p.place_id) AS favorite_count,
        ps.score AS place_score,
-       pm.path AS imageurl -- 추가
+       p.thumb_img_path AS imageurl
 FROM place p
 LEFT JOIN common_code c ON p.place_type = c.code_id
 LEFT JOIN favorite f ON p.place_id = f.place_id AND f.user_id = :userId
 LEFT JOIN opening_date o ON o.place_id = p.place_id
 LEFT JOIN place_score ps ON ps.place_id = p.place_id
-LEFT JOIN place_media pm ON pm.place_id = p.place_id -- 추가
 WHERE (:city IS NULL OR p.city LIKE CONCAT('%', :city, '%'))
   AND (:cityDetail IS NULL OR p.city_detail LIKE CONCAT('%', :cityDetail, '%'))
   AND (:placeType IS NULL OR :placeType = '' OR c.code_id = :placeType)
@@ -166,6 +160,7 @@ LIMIT 30;
             @Param("userId") Integer userId
     );
 
+
     @Query(value = """
 SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude,
        p.street_addresses, p.tel_number, p.url, c.name AS place_type, p.description,
@@ -180,19 +175,21 @@ SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.long
        CAST(o.end_time AS CHAR) AS end_time,
        (SELECT COUNT(f2.favorite_id) FROM favorite f2 WHERE f2.place_id = p.place_id) AS favorite_count,
        ps.score AS place_score,
-       pm.path AS imageurl
+       p.thumb_img_path AS imageurl -- 수정된 부분: thumb_img_path 사용
 FROM place p
 LEFT JOIN common_code c ON p.place_type = c.code_id
 LEFT JOIN favorite f ON p.place_id = f.place_id AND f.user_id = :userId
 LEFT JOIN opening_date o ON o.place_id = p.place_id
 LEFT JOIN place_score ps ON ps.place_id = p.place_id
-LEFT JOIN place_media pm ON pm.place_id = p.place_id
-WHERE (:keyword IS NULL OR p.name LIKE CONCAT('%', :keyword, '%'))
+WHERE (:keyword IS NULL 
+       OR MATCH(p.name) AGAINST(:formattedKeyword IN BOOLEAN MODE) 
+       OR p.name LIKE CONCAT('%', :keyword, '%'))
 ORDER BY distance ASC
 LIMIT 30;
 """, nativeQuery = true)
     List<Object[]> findByKeywordAndLocation(
             @Param("keyword") String keyword,
+            @Param("formattedKeyword") String formattedKeyword,
             @Param("latitude") Double latitude,
             @Param("longitude") Double longitude,
             @Param("userId") Integer userId

--- a/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
@@ -58,6 +58,10 @@ GROUP BY p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.lo
 SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude,
        p.street_addresses, p.tel_number, p.url, c.name AS place_type, p.description,
        p.parking, p.indoor, p.outdoor,
+       NULL AS distance,
+       CASE WHEN COUNT(f.favorite_id) > 0 THEN 1 ELSE 0 END AS is_favorite,
+       o.start_time AS start_time,   -- MIN 제거
+       o.end_time AS end_time,       -- MAX 제거
        COUNT(f.favorite_id) AS favorite_count,
        ps.score AS place_score,
        p.thumb_img_path AS imageurl
@@ -68,15 +72,12 @@ LEFT JOIN common_code c ON p.place_type = c.code_id
 LEFT JOIN place_score ps ON p.place_id = ps.place_id
 GROUP BY p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.longitude,
          p.street_addresses, p.tel_number, p.url, c.name, p.description,
-         p.parking, p.indoor, p.outdoor, ps.score, p.thumb_img_path
+         p.parking, p.indoor, p.outdoor, ps.score, p.thumb_img_path, o.start_time, o.end_time
 ORDER BY favorite_count DESC
 LIMIT 3;
+
 """, nativeQuery = true)
     List<Object[]> findTopFavoritePlaces();
-
-
-
-
 
 
     @Query(value = """

--- a/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
@@ -176,7 +176,7 @@ SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.long
        CAST(o.end_time AS CHAR) AS end_time,
        (SELECT COUNT(f2.favorite_id) FROM favorite f2 WHERE f2.place_id = p.place_id) AS favorite_count,
        ps.score AS place_score,
-       p.thumb_img_path AS imageurl -- 수정된 부분: thumb_img_path 사용
+       p.thumb_img_path AS imageurl
 FROM place p
 LEFT JOIN common_code c ON p.place_type = c.code_id
 LEFT JOIN favorite f ON p.place_id = f.place_id AND f.user_id = :userId

--- a/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
@@ -57,9 +57,15 @@ public class PlaceService {
 
     public List<PlaceDto> searchPlaces(String keyword, Double latitude, Double longitude, Integer userId) {
         Integer effectiveUserId = userId != null ? userId : -1;
-        List<Object[]> results = placeRepository.findByKeywordAndLocation(keyword, latitude, longitude, effectiveUserId);
+
+        String formattedKeyword = Arrays.stream(keyword.split("\\s+"))
+                .map(word -> word + "*")
+                .collect(Collectors.joining(" "));
+
+        List<Object[]> results = placeRepository.findByKeywordAndLocation(keyword, formattedKeyword, latitude, longitude, effectiveUserId);
         return results.stream().map(PlaceDtoMapper::convertToPlaceDto).collect(Collectors.toList());
     }
+
 
     private boolean checkIfUserFavoritedPlace(int placeId, Integer userId) {
         return placeRepository.existsFavoriteByPlaceIdAndUserId(placeId, userId);


### PR DESCRIPTION
# 📄 PR 변경사항
-  place_media 테이블을 join하는것이 아닌 place엔티티에서 이미지 가져오도록 변경
##쿼리개선
- 하버사인대신 mysql기본제공 구면체거리공식 사용 -> 오히려 쿼리 실행시간이 늘어남.
- 인덱싱 적용 -> 유의미한 차이를 느낄 수 없음.

# 쿼리 소요시간
### findPlaceDetailsById
0.016sec
### findTopFavoritePlaces
0.031sec
### findTopScoredPlacesWithinRadius
0.016sec
### findNearestPlaces
0.046sec

# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?

