### PR TITLE
feat/ 검색어 자동완성 기능

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/place/controller/PlaceController.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/controller/PlaceController.java
@@ -55,6 +55,12 @@ public class PlaceController {
         return ResponseEntity.ok(ApiResponse.success(places));
     }
 
+    @GetMapping("/autocomplete")
+    public ResponseEntity<ApiResponse<List<String>>> getAutocompleteSuggestions(@RequestParam String keyword) {
+        List<String> suggestions = placeService.getAutocompleteSuggestions(keyword);
+        return ResponseEntity.ok(ApiResponse.success(suggestions));
+    }
+
     @PostMapping("/search")
     public ResponseEntity<ApiResponse<List<PlaceDto>>> searchPlaces(
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User,

--- a/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
@@ -213,6 +213,9 @@ LIMIT 30;
             "FROM Favorite f WHERE f.place.placeId = :placeId AND f.user.userId = :userId")
     boolean existsFavoriteByPlaceIdAndUserId(@Param("placeId") int placeId, @Param("userId") int userId);
 
+    @Query(value = "SELECT DISTINCT p.name FROM place p WHERE p.name LIKE CONCAT('%', :keyword, '%') LIMIT 10", nativeQuery = true)
+    List<String> findPlaceNamesByPartialKeyword(@Param("keyword") String keyword);
+
 }
 
 

--- a/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
@@ -55,6 +55,10 @@ public class PlaceService {
         return results.stream().map(PlaceDtoMapper::convertToPlaceDto).collect(Collectors.toList());
     }
 
+    public List<String> getAutocompleteSuggestions(String keyword) {
+        return placeRepository.findPlaceNamesByPartialKeyword(keyword);
+    }
+
     public List<PlaceDto> searchPlaces(String keyword, Double latitude, Double longitude, Integer userId) {
         Integer effectiveUserId = userId != null ? userId : -1;
 


### PR DESCRIPTION
# 📄 PR 변경사항

### 자동완성 API 추가
- PlaceController에 /places/autocomplete 엔드포인트를 추가하여 사용자가 입력한 키워드를 기반으로 장소 이름을 자동완성할 수 있는 기능을 구현.

### Repository 메서드 추가
- PlaceRepository에 키워드로 시작하는 장소 이름을 조회하는 네이티브 쿼리 메서드를 추가.

### Service 메서드 추가
- PlaceService에 자동완성 로직을 처리하는 메서드를 추가.



# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->

![image](https://github.com/user-attachments/assets/fe38defb-8977-46eb-a43b-b44777558c2d)


# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?

