### PR TITLE
feat: 검색어 정확히 일치시 우선 출력

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
@@ -176,16 +176,19 @@ SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.long
        CAST(o.end_time AS CHAR) AS end_time,
        (SELECT COUNT(f2.favorite_id) FROM favorite f2 WHERE f2.place_id = p.place_id) AS favorite_count,
        ps.score AS place_score,
-       p.thumb_img_path AS imageurl
+       p.thumb_img_path AS imageurl,
+       CASE 
+           WHEN p.name = :keyword THEN 1  
+           ELSE 2                          
+       END AS relevance
 FROM place p
 LEFT JOIN common_code c ON p.place_type = c.code_id
 LEFT JOIN favorite f ON p.place_id = f.place_id AND f.user_id = :userId
 LEFT JOIN opening_date o ON o.place_id = p.place_id
 LEFT JOIN place_score ps ON ps.place_id = p.place_id
-WHERE (:keyword IS NULL 
-       OR MATCH(p.name) AGAINST(:formattedKeyword IN BOOLEAN MODE) 
-       OR p.name LIKE CONCAT('%', :keyword, '%'))
-ORDER BY distance ASC
+WHERE MATCH(p.name) AGAINST(:formattedKeyword IN BOOLEAN MODE)
+   OR p.name = :keyword
+ORDER BY relevance ASC, distance ASC
 LIMIT 30;
 """, nativeQuery = true)
     List<Object[]> findByKeywordAndLocation(
@@ -195,6 +198,8 @@ LIMIT 30;
             @Param("longitude") Double longitude,
             @Param("userId") Integer userId
     );
+
+
 
 
 


### PR DESCRIPTION
# 📄 PR 변경사항
- 검색 기능 개선: Place 엔티티의 검색에서 name이 키워드와 정확히 일치하는 결과를 최우선으로 반환하도록 수정.
- Full-Text Search : 키워드를 포함하는 결과를 Full-Text Search로 검색하고, 일치하지 않는 경우에는 거리순으로 정렬하여 반환.

###PlaceRepository 수정:
- 정확한 일치와 Full-Text Search를 결합한 쿼리 작성.
- 정확한 일치는 relevance 값으로 정렬.
- 거리순 정렬 적용.

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 
![image](https://github.com/user-attachments/assets/cbd360e1-6bc6-48f9-b257-c9c3f07da8c5)




# 확인
- [x] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?

