### PR TITLE
Refactor/story: 비회원유저 스토리조회 시, 확인여부에 무조건 unviewed 반환

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/story/service/StoryService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/story/service/StoryService.java
@@ -95,6 +95,7 @@ public class StoryService {
                         .city((String) row[2])
                         .cityDetail((String) row[3])
                         .petImage((String) row[4])
+                        .storyType("unviewed")
                         .build())
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
# 📄 PR 변경사항
- 비회원유저 스토리조회 시, 확인여부에 무조건 unviewed 반환

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
![image](https://github.com/user-attachments/assets/4ee05afb-c309-4fa5-9dc5-47f0bf421ae2)
- 프론트엔드의 기존 viewed/unviewed 구분에 따라 스토리 활성화를 표시하는 코드를 활용하기 위해 null이 아닌 unviewed로 고정 반환되도록 했습니다.

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [x] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?

