### PR TITLE
Refactor/review fetch : 리뷰 조회 동적쿼리 및 No-Offset으로 변경, 중복 리뷰/방문예정  예외처리

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/Global/enums/ErrorCode.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/Global/enums/ErrorCode.java
@@ -37,7 +37,8 @@ public enum ErrorCode {
 	USER_STORY_NOT_FOUND(HttpStatus.NOT_FOUND, "스토리가 존재하지 않습니다."),
 	USER_LAND_NOT_FOUND(HttpStatus.NOT_FOUND, "유저의 땅이 존재하지 않습니다."),
 	OWNER_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "땅 주인 히스토리에 존재하지 않습니다."),
-	DUPLICATE_REVIEW_DAY(HttpStatus.CONFLICT,"오늘 등록된 리뷰가 있습니다.");
+	DUPLICATE_REVIEW_DAY(HttpStatus.CONFLICT,"오늘 등록된 리뷰가 있습니다."),
+	DUPLICATE_VISIT(HttpStatus.CONFLICT,"동일한 시간대에 등록된 방문 예정 일정이 있습니다.");
 	private final HttpStatus errorCode;
 	private final String message;
 

--- a/src/main/java/com/daengdaeng_eodiga/project/Global/enums/ErrorCode.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/Global/enums/ErrorCode.java
@@ -36,7 +36,8 @@ public enum ErrorCode {
 	DAILY_STORY_UPLOAD_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "오늘 업로드 가능한 데이터 개수를 초과했습니다."),
 	USER_STORY_NOT_FOUND(HttpStatus.NOT_FOUND, "스토리가 존재하지 않습니다."),
 	USER_LAND_NOT_FOUND(HttpStatus.NOT_FOUND, "유저의 땅이 존재하지 않습니다."),
-	OWNER_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "땅 주인 히스토리에 존재하지 않습니다.");
+	OWNER_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "땅 주인 히스토리에 존재하지 않습니다."),
+	DUPLICATE_REVIEW_DAY(HttpStatus.CONFLICT,"오늘 등록된 리뷰가 있습니다.");
 	private final HttpStatus errorCode;
 	private final String message;
 

--- a/src/main/java/com/daengdaeng_eodiga/project/Global/exception/DuplicateReviewException.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/Global/exception/DuplicateReviewException.java
@@ -1,0 +1,9 @@
+package com.daengdaeng_eodiga.project.Global.exception;
+
+import com.daengdaeng_eodiga.project.Global.enums.ErrorCode;
+
+public class DuplicateReviewException extends BusinessException {
+    public DuplicateReviewException() {
+        super(ErrorCode.DUPLICATE_REVIEW_DAY.getErrorCode(), ErrorCode.DUPLICATE_REVIEW_DAY.getMessage());
+    }
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/Global/exception/DuplicateVisitException.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/Global/exception/DuplicateVisitException.java
@@ -1,0 +1,13 @@
+package com.daengdaeng_eodiga.project.Global.exception;
+
+import com.daengdaeng_eodiga.project.Global.enums.ErrorCode;
+/**
+ * 방문 예정 일정이 겹치면 발생하는 예외
+ *
+ * @author 김가은
+ * */
+public class DuplicateVisitException extends BusinessException {
+    public DuplicateVisitException() {
+        super(ErrorCode.DUPLICATE_VISIT.getErrorCode(), ErrorCode.DUPLICATE_VISIT.getMessage());
+    }
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/review/controller/ReviewController.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/review/controller/ReviewController.java
@@ -51,6 +51,12 @@ public class ReviewController {
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
+	@GetMapping("/reviews/place/no-offset/{placeId}/{orderType}")
+	public ResponseEntity<ApiResponse<ReviewsResponse>> fetchPlaceReviews2(@PathVariable int placeId, @PathVariable OrderType orderType, @RequestParam int lastReviewId, @RequestParam int lastScore,@Min(1) @RequestParam int size) {
+		ReviewsResponse response = reviewService.fetchPlaceReviewsByNoOffset(placeId,orderType,lastReviewId,lastScore,size);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
 	@GetMapping("/reviews/user")
 	public ResponseEntity<ApiResponse<ReviewsResponse>> fetchUserReviews(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @Min(0) @RequestParam int page, @Min(1)@RequestParam int size) {
 		int userId = customOAuth2User.getUserDTO().getUserid();

--- a/src/main/java/com/daengdaeng_eodiga/project/review/repository/ReviewRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/review/repository/ReviewRepository.java
@@ -5,14 +5,20 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import com.daengdaeng_eodiga.project.place.entity.Place;
 import com.daengdaeng_eodiga.project.review.entity.Review;
+import com.daengdaeng_eodiga.project.user.entity.User;
+
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
+import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Integer>, ReviewRepositoryCustom {
+
+	@Query("SELECT r FROM Review r WHERE r.user = :user AND r.place = :place AND  r.createdAt BETWEEN :startOfDay AND :endOfDay")
+	Optional<Review> findByUserAndPlaceAndCreatedAt(User user, Place place, LocalDateTime startOfDay, LocalDateTime endOfDay);
 
 	@Query(value = "SELECT "
 		+ "         u.user_id AS userId, r.place_id, u.nickname, "

--- a/src/main/java/com/daengdaeng_eodiga/project/review/repository/ReviewRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/review/repository/ReviewRepository.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 
-public interface ReviewRepository extends JpaRepository<Review, Integer> {
+public interface ReviewRepository extends JpaRepository<Review, Integer>, ReviewRepositoryCustom {
 
 	@Query(value = "SELECT "
 		+ "         u.user_id AS userId, r.place_id, u.nickname, "

--- a/src/main/java/com/daengdaeng_eodiga/project/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/review/repository/ReviewRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.daengdaeng_eodiga.project.review.repository;
+
+import java.util.List;
+
+import com.daengdaeng_eodiga.project.Global.enums.OrderType;
+import com.daengdaeng_eodiga.project.review.entity.Review;
+
+public interface ReviewRepositoryCustom {
+
+	List<Review> findAllByPlace(Integer placeId, OrderType orderType,int lastReviewId, int lastScore, int size);
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/review/repository/ReviewRepositoryCustomImpl.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/review/repository/ReviewRepositoryCustomImpl.java
@@ -1,0 +1,107 @@
+package com.daengdaeng_eodiga.project.review.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.daengdaeng_eodiga.project.Global.enums.OrderType;
+import com.daengdaeng_eodiga.project.pet.entity.QPet;
+import com.daengdaeng_eodiga.project.place.entity.QPlace;
+import com.daengdaeng_eodiga.project.review.entity.QReview;
+import com.daengdaeng_eodiga.project.review.entity.QReviewKeyword;
+import com.daengdaeng_eodiga.project.review.entity.QReviewMedia;
+import com.daengdaeng_eodiga.project.review.entity.QReviewPet;
+import com.daengdaeng_eodiga.project.review.entity.Review;
+import com.daengdaeng_eodiga.project.user.entity.QUser;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	/**
+	 *
+	 * OrderType 에 따라 특정 Place의 리뷰 목록을 정렬해서 조회한다.
+	 * No-offset으로 구현
+	 *
+	 * @auther : 김가은
+	 * @return : List<Review>
+	 */
+
+
+	@Override
+	public List<Review> findAllByPlace(Integer placeId, OrderType orderType, int lastReviewId, int lastScore,int size) {
+		QReview r = QReview.review;
+		QUser u = QUser.user;
+		QReviewPet rp = QReviewPet.reviewPet;
+		QPet p = QPet.pet;
+		QReviewKeyword rk = QReviewKeyword.reviewKeyword;
+		QReviewMedia rm = QReviewMedia.reviewMedia;
+		QPlace pl = QPlace.place;
+
+		return queryFactory
+			.select( r)
+			.from(r)
+			.leftJoin(r.user, u).fetchJoin()
+			.leftJoin(r.reviewPets, rp).fetchJoin()
+			.leftJoin(rp.pet, p).fetchJoin()
+			.leftJoin(r.reviewKeywords, rk)
+			.leftJoin(r.reviewMedias, rm)
+			.leftJoin(r.place, pl).fetchJoin()
+			.leftJoin(pl.placeScores).fetchJoin()
+			.where(pl.placeId.eq(placeId),getNonOffsetCondition(orderType, r, lastReviewId, lastScore))
+			.orderBy(getOrderSpecifier(orderType, r))
+			.limit(size)
+			.fetch();
+	}
+
+	/**
+	 *
+	 * OrderType 에 따라 정렬 조건을 반환한다.
+	 *
+	 * @auther : 김가은
+	 * @return : OrderSpecifier
+	 */
+
+	private OrderSpecifier getOrderSpecifier(OrderType orderType, QReview r) {
+
+		if(orderType == OrderType.LATEST){
+			return  new OrderSpecifier<>(Order.DESC, r.reviewId);
+		} else if (orderType == OrderType.HIGH_SCORE) {
+			return new OrderSpecifier<>(Order.DESC, r.score);
+		} else {
+			return new OrderSpecifier<>(Order.ASC, r.score);
+		}
+
+	}
+	/**
+	 *
+	 * 처음 조회한 경우, lastReviewId = 0 lastScore = -1 이다.
+	 *
+	 * @auther : 김가은
+	 * @return : BooleanExpression
+	 */
+
+	private BooleanExpression getNonOffsetCondition(OrderType orderType, QReview r, int lastReviewId, int lastScore) {
+
+		if(lastReviewId == 0 || lastScore == -1){
+			return null;
+		}
+
+		if(orderType == OrderType.LATEST){
+			return  r.reviewId.lt(lastReviewId);
+		} else if (orderType == OrderType.HIGH_SCORE) {
+			return r.score.lt(lastScore).or(r.score.eq(lastScore).and(r.reviewId.lt(lastReviewId)));
+		} else {
+			return r.score.gt(lastScore).or(r.score.eq(lastScore).and(r.reviewId.lt(lastReviewId)));
+		}
+
+	}
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/review/service/ReviewService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/review/service/ReviewService.java
@@ -157,7 +157,7 @@ public class ReviewService {
 
 	public ReviewsResponse fetchPlaceReviews(int placeId, int page, int size, OrderType orderType) {
 		Place place = placeService.findPlace(placeId);
-		Double scoreDouble = placeService.findPlaceScore(placeId);
+		Double scoreDouble = place.getPlaceScores().getScore();
 
 		DecimalFormat df = new DecimalFormat("#.##");
 		String score = df.format(scoreDouble);
@@ -177,6 +177,22 @@ public class ReviewService {
 
 		return response;
 	}
+
+	public ReviewsResponse fetchPlaceReviewsByNoOffset(int placeId, OrderType orderType, int lastReviewId, int lastScore,int size) {
+		Place place = placeService.findPlace(placeId);
+		Double scoreDouble = place.getPlaceScores().getScore();
+
+		DecimalFormat df = new DecimalFormat("#.##");
+		String score = df.format(scoreDouble);
+
+		List<Review> reviews = reviewRepository.findAllByPlace(place.getPlaceId(), orderType,lastReviewId<0?0:lastReviewId,lastScore<-1?-1:lastScore,size);
+		List<ReviewDto> reviewDtos = getReviewDtoByReviewByReview(reviews);
+		List<String> keywords = reviewKeywordsService.fetchBestReviewKeywordsTop3(placeId);
+		ReviewsResponse response = new ReviewsResponse(reviewDtos,0,0,reviews.size(),false,false,orderType,score,keywords.stream().map(keyword -> commonCodeService.getCommonCodeName(keyword)).collect(Collectors.toList()));
+
+		return response;
+	}
+
 
 	public ReviewsResponse fetchUserReviews(int userId,int page, int size) {
 		User user = userService.findUser(userId);
@@ -222,6 +238,40 @@ public class ReviewService {
 		}
 		return reviews;
 	}
+
+	private List<ReviewDto> getReviewDtoByReviewByReview(List<Review> reviews) {
+		List<ReviewDto> reviewDtos = new ArrayList<>();
+		for (Review review : reviews) {
+
+			LocalDate visitedAt = review.getVisitedAt();
+			LocalDateTime createdAt = review.getCreatedAt();
+			User user = review.getUser();
+
+			List<String> pets = review.getReviewPets().stream().map(pet -> pet.getPet().getName()).toList();
+			List<String> media = review.getReviewMedias().stream().map(ReviewMedia::getPath).toList();
+			List<String> keywords = review.getReviewKeywords().stream().map(keyword -> commonCodeService.getCommonCodeName(keyword.getId().getKeyword()) ).collect(Collectors.toList());
+
+			ReviewDto reviewDto = new ReviewDto(
+				user.getUserId(),
+				review.getPlace().getPlaceId(),
+				user.getNickname(),
+				review.getReviewPets().size()>0 ? review.getReviewPets().get(0).getPet().getImage() : null,
+				review.getReviewId(),
+				pets,
+				review.getContent(),
+				review.getScore(),
+				media,
+				keywords,
+				visitedAt,
+				createdAt,
+				review.getPlace().getName(),
+				commonCodeService.getCommonCodeName(review.getReviewtype())
+			);
+			reviewDtos.add(reviewDto);
+		}
+		return reviewDtos;
+	}
+
 
 	private static List<String> getStrings(String str) {
 		List<String> pets;

--- a/src/main/java/com/daengdaeng_eodiga/project/visit/repository/VisitRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/visit/repository/VisitRepository.java
@@ -2,11 +2,13 @@ package com.daengdaeng_eodiga.project.visit.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import com.daengdaeng_eodiga.project.notification.entity.PushToken;
+import com.daengdaeng_eodiga.project.user.entity.User;
 import com.daengdaeng_eodiga.project.visit.dto.VisitInfo;
 import com.daengdaeng_eodiga.project.visit.entity.Visit;
 
@@ -35,4 +37,13 @@ public interface VisitRepository extends JpaRepository<Visit, Integer> {
 		"AND u.deletedAt IS NULL "
 	)
 	List<PushToken> findPushTokenByVisitId(int visitId,int userId);
+
+	/**
+	 * 동일한 시간에 방문 예정이 등록되어 있는지 조회
+	 *
+	 * @author 김가은
+	 * */
+
+	@Query("SELECT v FROM Visit v WHERE v.visitAt BETWEEN :startTime AND :endTime AND v.user = :user")
+	Optional<Visit> findByUserAndVisitAt( User user, LocalDateTime startTime, LocalDateTime endTime);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
   jpa:
     properties:
       hibernate:
+        default_batch_fetch_size: 1000
         jdbc:
           time_zone: UTC
     hibernate:
@@ -67,6 +68,11 @@ spring:
       initialize-schema: always
     job:
       enabled: false
+
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 kakao:
   api:


### PR DESCRIPTION
# 📄 PR 변경사항
- 리뷰 조회 동적쿼리 및 No-Offset으로 변경
-  중복 리뷰 방지 예외처리
- 중복 방문 예정 일정 예외 처리

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
-   리뷰 조회 동적쿼리 및 No-Offset으로 변경
    - 리뷰 조회시, 여러 정렬 조건이 있는데, JPQL로 작성하니 정렬 조건의 개수에 맞는 쿼리들이 필요했었습니다.
    - 정렬 조건에 맞게 쿼리를 동적으로 관리하기 위해 QueryDsl을 도입하였습니다.
    - offset으로 리뷰를 조회할 때 뒤로 갈 수록, 조회 성능 저하 문제가 발생했습니다.
    - 원인은 원하는 offset으로 도달하기 전까지 이전 데이터들을 다 읽고 넘어가야한다는 점이 문제였으며, 이를 개선하고자 No offset으로 변경하여 개선하였습니다. 

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 별점순일 때 실행 계획을 분석하여 인덱스가 적용이 되는지 확인이 필요합니다.


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 장소별 리뷰 조회
<img width="925" alt="image" src="https://github.com/user-attachments/assets/053ce981-67f0-4614-897e-185bd03f4929" />

- 중복 리뷰 방지
<img width="919" alt="image" src="https://github.com/user-attachments/assets/f247cc1b-d6f4-49b1-8b6e-74d54cad7cba" />

- 중복 방문 예정 등록 방지
<img width="947" alt="image" src="https://github.com/user-attachments/assets/83111a0d-95cc-4d86-9a3b-55bba1582c5c" />



# 확인
- [x] 주석 및 print를 제거하셨나요?
- [x] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?

