### PR TITLE
검색 기능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,11 @@ dependencies {
   
 	//Thumbnailator
 	implementation 'net.coobird:thumbnailator:0.4.20'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.mockito:mockito-core'
+	testImplementation 'org.mockito:mockito-junit-jupiter'
+
 }
 
 def querydslDir = "src/main/generated/qClass"

--- a/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/repository/PlaceRepository.java
@@ -176,19 +176,15 @@ SELECT p.place_id, p.name, p.city, p.city_detail, p.township, p.latitude, p.long
        CAST(o.end_time AS CHAR) AS end_time,
        (SELECT COUNT(f2.favorite_id) FROM favorite f2 WHERE f2.place_id = p.place_id) AS favorite_count,
        ps.score AS place_score,
-       p.thumb_img_path AS imageurl,
-       CASE 
-           WHEN p.name = :keyword THEN 1  
-           ELSE 2                          
-       END AS relevance
+       p.thumb_img_path AS imageurl
 FROM place p
 LEFT JOIN common_code c ON p.place_type = c.code_id
 LEFT JOIN favorite f ON p.place_id = f.place_id AND f.user_id = :userId
 LEFT JOIN opening_date o ON o.place_id = p.place_id
 LEFT JOIN place_score ps ON ps.place_id = p.place_id
 WHERE MATCH(p.name) AGAINST(:formattedKeyword IN BOOLEAN MODE)
-   OR p.name = :keyword
-ORDER BY relevance ASC, distance ASC
+   OR p.name LIKE CONCAT('%', :keyword, '%')
+ORDER BY distance ASC
 LIMIT 30;
 """, nativeQuery = true)
     List<Object[]> findByKeywordAndLocation(
@@ -198,6 +194,7 @@ LIMIT 30;
             @Param("longitude") Double longitude,
             @Param("userId") Integer userId
     );
+
 
 
 

--- a/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
@@ -62,13 +62,15 @@ public class PlaceService {
     public List<PlaceDto> searchPlaces(String keyword, Double latitude, Double longitude, Integer userId) {
         Integer effectiveUserId = userId != null ? userId : -1;
 
+        if (latitude == 0.0 && longitude == 0.0) {
+            latitude = 37.5664056;
+            longitude = 126.9778222;
+        }
 
         String formattedKeyword = Arrays.stream(keyword.split("\\s+"))
                 .map(word -> word + "*")
                 .collect(Collectors.joining(" "));
-
         String likeKeyword = "%" + keyword.replace(" ", "%") + "%";
-
         List<Object[]> results = placeRepository.findByKeywordAndLocation(likeKeyword, formattedKeyword, latitude, longitude, effectiveUserId);
         return results.stream().map(PlaceDtoMapper::convertToPlaceDto).collect(Collectors.toList());
     }

--- a/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/service/PlaceService.java
@@ -62,13 +62,17 @@ public class PlaceService {
     public List<PlaceDto> searchPlaces(String keyword, Double latitude, Double longitude, Integer userId) {
         Integer effectiveUserId = userId != null ? userId : -1;
 
+
         String formattedKeyword = Arrays.stream(keyword.split("\\s+"))
                 .map(word -> word + "*")
                 .collect(Collectors.joining(" "));
 
-        List<Object[]> results = placeRepository.findByKeywordAndLocation(keyword, formattedKeyword, latitude, longitude, effectiveUserId);
+        String likeKeyword = "%" + keyword.replace(" ", "%") + "%";
+
+        List<Object[]> results = placeRepository.findByKeywordAndLocation(likeKeyword, formattedKeyword, latitude, longitude, effectiveUserId);
         return results.stream().map(PlaceDtoMapper::convertToPlaceDto).collect(Collectors.toList());
     }
+
 
 
     private boolean checkIfUserFavoritedPlace(int placeId, Integer userId) {

--- a/src/test/java/com/daengdaeng_eodiga/project/PlaceServiceTest.java
+++ b/src/test/java/com/daengdaeng_eodiga/project/PlaceServiceTest.java
@@ -1,0 +1,159 @@
+package com.daengdaeng_eodiga.project;
+
+
+import com.daengdaeng_eodiga.project.Global.Redis.Repository.RedisLocationRepository;
+import com.daengdaeng_eodiga.project.Global.exception.PlaceNotFoundException;
+import com.daengdaeng_eodiga.project.common.service.CommonCodeService;
+import com.daengdaeng_eodiga.project.place.dto.PlaceDto;
+import com.daengdaeng_eodiga.project.place.entity.Place;
+import com.daengdaeng_eodiga.project.place.repository.PlaceRepository;
+import com.daengdaeng_eodiga.project.place.repository.PlaceScoreRepository;
+import com.daengdaeng_eodiga.project.place.service.OpenAiService;
+import com.daengdaeng_eodiga.project.place.service.PlaceService;
+import com.daengdaeng_eodiga.project.preference.repository.PreferenceRepository;
+import com.daengdaeng_eodiga.project.review.entity.Review;
+import com.daengdaeng_eodiga.project.review.repository.ReviewRepository;
+import com.daengdaeng_eodiga.project.review.repository.ReviewSummaryRepository;
+import com.daengdaeng_eodiga.project.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.List;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PlaceServiceTest {
+
+    @Mock
+    private PlaceRepository placeRepository;
+
+    @Mock
+    private PlaceScoreRepository placeScoreRepository;
+
+    @Mock
+    private PreferenceRepository preferenceRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private ReviewSummaryRepository reviewSummaryRepository;
+
+    @Mock
+    private OpenAiService openAiService;
+
+    @Mock
+    private CommonCodeService commonCodeService;
+
+    @Mock
+    private RedisLocationRepository redisLocationRepository;
+
+    @InjectMocks
+    private PlaceService placeService;
+
+    private Place samplePlace;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        samplePlace = Place.builder()
+                .name("Sample Place")
+                .city("Seoul")
+                .cityDetail("Gangnam")
+                .township("Sinsa-dong")
+                .latitude(37.5165)
+                .longitude(127.0190)
+                .streetAddresses("123 Sample Street")
+                .telNumber("010-1234-5678")
+                .url("http://sampleplace.com")
+                .placeType("Cafe")
+                .description("A nice place to relax.")
+                .parking(true)
+                .indoor(true)
+                .outdoor(false)
+                .thumbImgPath("sample.jpg")
+                .build();
+    }
+
+    @Test
+    void testGetPlaceDetails_Success() {
+        when(placeRepository.findPlaceDetailsById(1)).thenReturn(Arrays.asList(new Object[][] {
+                {
+                        1, "Sample Place", "Seoul", "Gangnam", "Sinsa-dong", 37.5165, 127.0190,
+                        "123 Sample Street", "010-1234-5678", "http://sampleplace.com",
+                        "Cafe", "A nice place to relax.", true, true, false,
+                        null, false, null, null, 0, 4.5, "sample.jpg"
+                }
+        }));
+
+
+
+        PlaceDto result = placeService.getPlaceDetails(1, 1);
+
+        assertNotNull(result);
+        assertEquals("Sample Place", result.getName());
+        verify(placeRepository, times(1)).findPlaceDetailsById(1);
+    }
+
+    @Test
+    void testGetPlaceDetails_NotFound() {
+        when(placeRepository.findPlaceDetailsById(1)).thenReturn(Collections.emptyList());
+
+        assertThrows(PlaceNotFoundException.class, () -> placeService.getPlaceDetails(1, 1));
+        verify(placeRepository, times(1)).findPlaceDetailsById(1);
+    }
+
+    @Test
+    void testFindPlace_Success() {
+        when(placeRepository.findById(1)).thenReturn(Optional.of(samplePlace));
+
+        Place result = placeService.findPlace(1);
+
+        assertNotNull(result);
+        assertEquals("Sample Place", result.getName());
+        verify(placeRepository, times(1)).findById(1);
+    }
+
+    @Test
+    void testFindPlace_NotFound() {
+        when(placeRepository.findById(1)).thenReturn(Optional.empty());
+
+        assertThrows(PlaceNotFoundException.class, () -> placeService.findPlace(1));
+        verify(placeRepository, times(1)).findById(1);
+    }
+
+    @Test
+    void testGenerateReviewSummary_ValidReviews() {
+        User mockUser = mock(User.class);
+
+        when(placeRepository.findById(1)).thenReturn(Optional.of(samplePlace));
+        when(reviewRepository.findByPlace_PlaceId(1)).thenReturn(List.of(
+                Review.builder().score(5).content("좋아요!").visitedAt(LocalDate.now()).place(samplePlace).user(mockUser).reviewtype("Positive").build(),
+                Review.builder().score(2).content("별로예요!").visitedAt(LocalDate.now()).place(samplePlace).user(mockUser).reviewtype("Negative").build()
+        ));
+
+        placeService.generateReviewSummary(1);
+
+        verify(reviewRepository, times(1)).findByPlace_PlaceId(1);
+    }
+
+    @Test
+    void testSavePlace() {
+        when(placeRepository.save(any(Place.class))).thenReturn(samplePlace);
+
+        Place result = placeService.savePlace(samplePlace);
+
+        assertNotNull(result);
+        assertEquals("Sample Place", result.getName());
+        verify(placeRepository, times(1)).save(samplePlace);
+    }
+}


### PR DESCRIPTION
# 📄 PR 변경사항

### PlaceRepository

- Full-Text 검색과 함께 LIKE 검색을 수행하는 쿼리로 변경.
- 기존 Full-Text 검색에 LIKE 조건을 추가하여 키워드 포함 검색이 가능.

### PlaceService

- searchPlaces 메서드에서 키워드를 Full-Text와 LIKE에 맞게 변환하는 로직을 추가.
- Full-Text 검색과 LIKE 검색을 결합하여 장소 검색을 수행하도록 변경.



# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 
![image](https://github.com/user-attachments/assets/f13e8a10-a062-4cfa-aadc-ada48eb7edac)




# 확인
- [ ] 주석 및 print를 제거하셨나요?
- [ ] javaDoc을 작성하셨나요?
- [ ] merge할 브랜치와 로컬에서 merge 하셨나요?
- [ ] 더 수정할 작업은 없는지 확인하셨나요?

