### PR TITLE
Feat/story: 스토리 서비스에 Redis 적용

### DIFF
--- a/src/main/java/com/daengdaeng_eodiga/project/Global/Redis/Repository/RedisStoryRepository.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/Global/Redis/Repository/RedisStoryRepository.java
@@ -1,0 +1,79 @@
+package com.daengdaeng_eodiga.project.Global.Redis.Repository;
+
+import com.daengdaeng_eodiga.project.story.dto.RedisGroupedUserStoriesDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Repository
+public class RedisStoryRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    public RedisStoryRepository(@Qualifier("storyRedisTemplate") RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * 레디스에 스토리를 저장하는 메소드
+     * @param city
+     * @param cityDetail
+     * @param userId
+     * @param storyId
+     * @param story
+     */
+    public void saveStory(String city, String cityDetail, int userId, int storyId, RedisGroupedUserStoriesDto story) {
+        String key = generateKey(city, cityDetail, userId, storyId);
+        redisTemplate.opsForValue().set(key, story, Duration.ofHours(24)); // TTL 24시간 설정
+    }
+
+    /**
+     * 레디스로부터 모든 스토리를 조회하는 메소드
+     * @return
+     */
+    public List<RedisGroupedUserStoriesDto> getAllStories() {
+        Set<String> keys = redisTemplate.keys("story:*");
+        List<RedisGroupedUserStoriesDto> allStories = new ArrayList<>();
+
+        if (keys != null) {
+            for (String key : keys) {
+                RedisGroupedUserStoriesDto story = (RedisGroupedUserStoriesDto) redisTemplate.opsForValue().get(key);
+                if (story != null) {
+                    allStories.add(story);
+                }
+            }
+        }
+        return allStories;
+    }
+
+    /**
+     * 레디스에서 스토리 삭제하는 메소드
+     * @param city
+     * @param cityDetail
+     * @param userId
+     * @param storyId
+     */
+    public void deleteStory(String city, String cityDetail, int userId, int storyId) {
+        String key = generateKey(city, cityDetail, userId, storyId);
+        redisTemplate.delete(key);
+    }
+
+    /**
+     * 키 생성 메소드
+     * @param city
+     * @param cityDetail
+     * @param userId
+     * @param storyId
+     * @return
+     */
+    private String generateKey(String city, String cityDetail, int userId, int storyId) {
+        return String.format("story:%s:%s:%d:%d", city, cityDetail, userId, storyId);
+    }
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/Global/Redis/config/RedisConfig.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/Global/Redis/config/RedisConfig.java
@@ -47,4 +47,14 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
     }
+    @Bean
+    public RedisTemplate<?, ?> storyRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.afterPropertiesSet();
+        return redisTemplate;
+    }
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/Global/entity/BaseEntity.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/Global/entity/BaseEntity.java
@@ -2,6 +2,7 @@ package com.daengdaeng_eodiga.project.Global.entity;
 
 import java.time.LocalDateTime;
 
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -13,6 +14,7 @@ import lombok.Getter;
 
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@Setter
 @MappedSuperclass
 public class BaseEntity {
 

--- a/src/main/java/com/daengdaeng_eodiga/project/common/entity/CommonCode.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/common/entity/CommonCode.java
@@ -1,6 +1,7 @@
 package com.daengdaeng_eodiga.project.common.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 
 @Entity
@@ -17,5 +18,11 @@ public class CommonCode {
 
     private String name;
 
-
+    @Builder
+    public CommonCode(String codeId, GroupCode groupCode, String name) {
+        this.codeId = codeId;
+        this.groupCode = groupCode;
+        this.name = name;
+    }
+    public CommonCode() {}
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/common/entity/GroupCode.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/common/entity/GroupCode.java
@@ -1,6 +1,7 @@
 package com.daengdaeng_eodiga.project.common.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.ArrayList;
@@ -19,4 +20,10 @@ public class GroupCode {
     @OneToMany(mappedBy = "groupCode", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CommonCode> commonCodes = new ArrayList<>();
 
+    @Builder
+    public GroupCode(String groupId, String name) {
+        this.groupId = groupId;
+        this.name = name;
+    }
+    public GroupCode() {}
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/event/entity/Event.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/event/entity/Event.java
@@ -2,7 +2,9 @@ package com.daengdaeng_eodiga.project.event.entity;
 
 import com.daengdaeng_eodiga.project.Global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 import java.time.LocalDate;
@@ -10,6 +12,7 @@ import java.time.LocalDate;
 @Entity
 @ToString
 @Getter
+@Setter
 @Table(name = "event")
 public class Event extends BaseEntity {
 
@@ -37,4 +40,16 @@ public class Event extends BaseEntity {
 
     @Column(name = "end_date")
     private LocalDate endDate;
+
+    @Builder
+    public Event(String eventName, String eventImage, String eventDescription, String placeName, String placeAddress, LocalDate startDate, LocalDate endDate) {
+        this.eventName = eventName;
+        this.eventImage = eventImage;
+        this.eventDescription = eventDescription;
+        this.placeName = placeName;
+        this.placeAddress = placeAddress;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+    public Event() {}
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/favorite/dto/FavoriteRequestDto.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/favorite/dto/FavoriteRequestDto.java
@@ -7,4 +7,9 @@ import lombok.Getter;
 public class FavoriteRequestDto {
     @NotNull(message = "장소 ID가 필요함")
     private Integer placeId;
+
+    public FavoriteRequestDto(Integer placeId) {
+        this.placeId = placeId;
+    }
+    public FavoriteRequestDto() {}
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/favorite/entity/Favorite.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/favorite/entity/Favorite.java
@@ -6,9 +6,11 @@ import com.daengdaeng_eodiga.project.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @Table(name = "Favorite")
 public class Favorite extends BaseEntity {
     @Id

--- a/src/main/java/com/daengdaeng_eodiga/project/favorite/service/FavoriteService.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/favorite/service/FavoriteService.java
@@ -115,6 +115,7 @@ public class FavoriteService {
         String startTime = openingDate != null ? openingDate.getStartTime() : OpenHoursType.NO_INFO.getDescription();
         String endTime = openingDate != null ? openingDate.getEndTime() : OpenHoursType.NO_INFO.getDescription();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        String updatedAt = favorite.getUpdatedAt() != null ? favorite.getUpdatedAt().format(formatter) : "N/A";
 
         return FavoriteResponseDto.builder()
                 .favoriteId(favorite.getFavoriteId())
@@ -127,7 +128,7 @@ public class FavoriteService {
                 .longitude(place.getLongitude())
                 .startTime(startTime)
                 .endTime(endTime)
-                .updatedAt((favorite.getUpdatedAt()).format(formatter))
+                .updatedAt(updatedAt)
                 .build();
     }
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/pet/dto/PetRegisterDto.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/pet/dto/PetRegisterDto.java
@@ -3,6 +3,7 @@ package com.daengdaeng_eodiga.project.pet.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -27,4 +28,16 @@ public class PetRegisterDto {
 
     @NotNull(message = "중성화 여부가 필요함")
     private Boolean neutering;
+
+    @Builder
+    public PetRegisterDto(String name, String image, String species, String birthday, String gender, String size, Boolean neutering) {
+        this.name = name;
+        this.image = image;
+        this.species = species;
+        this.birthday = birthday;
+        this.gender = gender;
+        this.size = size;
+        this.neutering = neutering;
+    }
+    public PetRegisterDto() {}
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/pet/dto/PetUpdateDto.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/pet/dto/PetUpdateDto.java
@@ -3,6 +3,7 @@ package com.daengdaeng_eodiga.project.pet.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -28,4 +29,16 @@ public class PetUpdateDto {
 
     @NotNull(message = "중성화 여부가 필요함")
     private Boolean neutering;
+
+    @Builder
+    public PetUpdateDto(String name, String image, String species, String gender, String size, String birthday, Boolean neutering) {
+        this.name = name;
+        this.image = image;
+        this.species = species;
+        this.gender = gender;
+        this.size = size;
+        this.birthday = birthday;
+        this.neutering = neutering;
+    }
+    public PetUpdateDto() {}
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/place/entity/OpeningDate.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/place/entity/OpeningDate.java
@@ -1,10 +1,13 @@
 package com.daengdaeng_eodiga.project.place.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @Table(name = "opening_date")
 public class OpeningDate {
     @Id
@@ -24,4 +27,13 @@ public class OpeningDate {
 
     @Column(name = "end_time")
     private String endTime;
+
+    @Builder
+    public OpeningDate(Place place, String dayType, String startTime, String endTime) {
+        this.place = place;
+        this.dayType = dayType;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+    public OpeningDate() {}
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/preference/dto/PreferenceRequestDto.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/preference/dto/PreferenceRequestDto.java
@@ -14,4 +14,9 @@ public class PreferenceRequestDto {
     @NotEmpty(message = "공통코드 Set이 존재해야 함")
     @Size(min = 1, message = "공통코드는 최소 1개의 값을 가져야 함")
     private Set<String> preferenceTypes;
+
+    public PreferenceRequestDto(String preferenceInfo, Set<String> preferenceTypes) {
+        this.preferenceInfo = preferenceInfo;
+        this.preferenceTypes = preferenceTypes;
+    }
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/preference/entity/PreferenceId.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/preference/entity/PreferenceId.java
@@ -1,6 +1,7 @@
 package com.daengdaeng_eodiga.project.preference.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -34,4 +35,10 @@ public class PreferenceId implements Serializable {
         return result;
     }
 
+    @Builder
+    public PreferenceId(String preferenceInfo, int userId) {
+        this.preferenceInfo = preferenceInfo;
+        this.userId = userId;
+    }
+    public PreferenceId(){}
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/story/controller/StoryController.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/story/controller/StoryController.java
@@ -30,11 +30,11 @@ public class StoryController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<GroupedUserStoriesDto>>> fetchGroupedUserStories(
+    public ResponseEntity<ApiResponse<List<?>>> fetchGroupedUserStories(
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ){
         Integer userId = customOAuth2User == null ? null : customOAuth2User.getUserDTO().getUserid();
-        List<GroupedUserStoriesDto> response;
+        List<?> response;
         response = (userId == null) ? storyService.fetchGroupedUserStoriesForNotUser() : storyService.fetchGroupedUserStories(userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -51,8 +51,8 @@ public class StoryController {
     @GetMapping("/detail/{landOwnerId}")
     public ResponseEntity<ApiResponse<IndividualUserStoriesDto>> fetchIndividualUserStories(
             @PathVariable int landOwnerId,
-            @RequestParam String city,
-            @RequestParam String cityDetail
+            @RequestParam("city") String city,
+            @RequestParam("cityDetail") String cityDetail
     ){
         IndividualUserStoriesDto response = storyService.fetchIndividualUserStories(landOwnerId, city, cityDetail);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -60,7 +60,7 @@ public class StoryController {
 
     @PutMapping("/{storyId}/viewed")
     public ResponseEntity<ApiResponse<String>> viewStory(
-            @Min (1) @PathVariable int storyId,
+            @Min (1) @PathVariable("storyId") int storyId,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ){
         int userId = customOAuth2User.getUserDTO().getUserid();
@@ -70,7 +70,7 @@ public class StoryController {
 
     @DeleteMapping("/{storyId}")
     public ResponseEntity<ApiResponse<String>> deleteStory(
-            @Min (1) @PathVariable int storyId
+            @Min (1) @PathVariable("storyId") int storyId
     ){
         storyService.deleteStory(storyId);
         return ResponseEntity.ok(ApiResponse.success("story deleted successfully"));

--- a/src/main/java/com/daengdaeng_eodiga/project/story/dto/GroupedUserStoriesDto.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/story/dto/GroupedUserStoriesDto.java
@@ -30,4 +30,6 @@ public class GroupedUserStoriesDto {
         this.cityDetail = cityDetail;
         this.petImage = petImage;
     }
+
+    public GroupedUserStoriesDto(){}
 }

--- a/src/main/java/com/daengdaeng_eodiga/project/story/dto/RedisGroupedUserStoriesDto.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/story/dto/RedisGroupedUserStoriesDto.java
@@ -1,0 +1,28 @@
+package com.daengdaeng_eodiga.project.story.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class RedisGroupedUserStoriesDto {
+    private int landOwnerId;
+    private int storyId;
+    private String nickname;
+    private String city;
+    private String cityDetail;
+    private String petImage;
+    private String storyType;
+
+    @Builder
+    public RedisGroupedUserStoriesDto(int landOwnerId, String nickname, String city, String cityDetail, String petImage, String storyType, int storyId) {
+        this.landOwnerId = landOwnerId;
+        this.nickname = nickname;
+        this.city = city;
+        this.cityDetail = cityDetail;
+        this.petImage = petImage;
+        this.storyType = storyType;
+        this.storyId = storyId;
+    }
+
+    public RedisGroupedUserStoriesDto(){}
+}

--- a/src/main/java/com/daengdaeng_eodiga/project/user/entity/User.java
+++ b/src/main/java/com/daengdaeng_eodiga/project/user/entity/User.java
@@ -88,4 +88,17 @@ public class User extends BaseEntity {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private List<RegionVisitTotal> regionVisitTotals = new ArrayList<>();
 
+    @Builder
+    public User (int userId, String nickname, String gender, String email, String city, String cityDetail, String oauthProvider, LocalDateTime deletedAt ) {
+        this.userId = userId;
+        this.nickname = nickname;
+        this.gender = gender;
+        this.email = email;
+        this.city = city;
+        this.cityDetail = cityDetail;
+        this.oauthProvider = OauthProvider.valueOf(oauthProvider);
+        this.deletedAt = deletedAt;
+    }
+    public User(){}
+
 }

--- a/src/test/java/com/daengdaeng_eodiga/project/banner/BannerServiceTest.java
+++ b/src/test/java/com/daengdaeng_eodiga/project/banner/BannerServiceTest.java
@@ -1,0 +1,87 @@
+package com.daengdaeng_eodiga.project.banner;
+
+import com.daengdaeng_eodiga.project.banner.dto.BannersDto;
+import com.daengdaeng_eodiga.project.banner.service.BannerService;
+import com.daengdaeng_eodiga.project.event.entity.Event;
+import com.daengdaeng_eodiga.project.event.repository.EventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+class BannerServiceTest {
+
+    @InjectMocks
+    private BannerService bannerService;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void fetchBanners_ShouldReturnListOfBannersDto() {
+        Event event1 = Event.builder()
+                .eventName("Event 1")
+                .eventImage("https://example.com/event1.png")
+                .eventDescription("Description 1")
+                .placeName("Place 1")
+                .placeAddress("Address 1")
+                .startDate(LocalDate.of(2024, 12, 1))
+                .endDate(LocalDate.of(2024, 12, 31))
+                .build();
+        event1.setEventId(1);
+
+        Event event2 = Event.builder()
+                .eventName("Event 2")
+                .eventImage("https://example.com/event2.png")
+                .eventDescription("Description 2")
+                .placeName("Place 2")
+                .placeAddress("Address 2")
+                .startDate(LocalDate.of(2024, 11, 1))
+                .endDate(LocalDate.of(2024, 11, 30))
+                .build();
+        event2.setEventId(2);
+
+        when(eventRepository.findActiveEvents(any(LocalDate.class))).thenReturn(Arrays.asList(event1, event2));
+
+        List<BannersDto> result = bannerService.fetchBanners();
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        BannersDto banner1 = result.get(0);
+        assertEquals(1, banner1.getEventId());
+        assertEquals("Event 1", banner1.getEventName());
+        assertEquals("https://example.com/event1.png", banner1.getEventImage());
+        assertEquals("Description 1", banner1.getEventDescription());
+        assertEquals("Place 1", banner1.getPlaceName());
+        assertEquals("Address 1", banner1.getPlaceAddress());
+        assertEquals("2024-12-01", banner1.getStartDate());
+        assertEquals("2024-12-31", banner1.getEndDate());
+
+        BannersDto banner2 = result.get(1);
+        assertEquals(2, banner2.getEventId());
+        assertEquals("Event 2", banner2.getEventName());
+        assertEquals("https://example.com/event2.png", banner2.getEventImage());
+        assertEquals("Description 2", banner2.getEventDescription());
+        assertEquals("Place 2", banner2.getPlaceName());
+        assertEquals("Address 2", banner2.getPlaceAddress());
+        assertEquals("2024-11-01", banner2.getStartDate());
+        assertEquals("2024-11-30", banner2.getEndDate());
+
+        verify(eventRepository, times(1)).findActiveEvents(any(LocalDate.class));
+    }
+}

--- a/src/test/java/com/daengdaeng_eodiga/project/favorite/FavoriteServiceTest.java
+++ b/src/test/java/com/daengdaeng_eodiga/project/favorite/FavoriteServiceTest.java
@@ -1,0 +1,188 @@
+package com.daengdaeng_eodiga.project.favorite;
+
+import com.daengdaeng_eodiga.project.Global.exception.*;
+import com.daengdaeng_eodiga.project.common.service.CommonCodeService;
+import com.daengdaeng_eodiga.project.favorite.dto.FavoriteRequestDto;
+import com.daengdaeng_eodiga.project.favorite.dto.FavoriteResponseDto;
+import com.daengdaeng_eodiga.project.favorite.entity.Favorite;
+import com.daengdaeng_eodiga.project.favorite.repository.FavoriteRepository;
+import com.daengdaeng_eodiga.project.favorite.service.FavoriteService;
+import com.daengdaeng_eodiga.project.place.entity.OpeningDate;
+import com.daengdaeng_eodiga.project.place.entity.Place;
+import com.daengdaeng_eodiga.project.place.entity.PlaceMedia;
+import com.daengdaeng_eodiga.project.place.repository.OpeningDateRepository;
+import com.daengdaeng_eodiga.project.place.repository.PlaceMediaRepository;
+import com.daengdaeng_eodiga.project.place.repository.PlaceRepository;
+import com.daengdaeng_eodiga.project.user.entity.User;
+import com.daengdaeng_eodiga.project.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.daengdaeng_eodiga.project.place.entity.QOpeningDate.openingDate;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class FavoriteServiceTest {
+
+    @Mock
+    private FavoriteRepository favoriteRepository;
+
+    @Mock
+    private PlaceRepository placeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private OpeningDateRepository openingDateRepository;
+
+    @Mock
+    private PlaceMediaRepository placeMediaRepository;
+
+    @Mock
+    private CommonCodeService commonCodeService;
+
+    @InjectMocks
+    private FavoriteService favoriteService;
+
+    private User sampleUser;
+    private Place samplePlace;
+    private Favorite sampleFavorite;
+    private PlaceMedia samplePlaceMedia;
+    private OpeningDate sampleOpeningDate;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        sampleUser = User.builder()
+                .userId(1)
+                .nickname("user1")
+                .email("user1@example.com")
+                .gender("GND_01")
+                .city("광주")
+                .cityDetail("광산구")
+                .oauthProvider("google")
+                .build();
+
+        samplePlace = Place.builder()
+                .name("Sample Place")
+                .latitude(35.12345)
+                .longitude(127.56789)
+                .placeType("PLACE_TYPE")
+                .streetAddresses("123 Sample St")
+                .thumbImgPath("https://example.com/thumb.png")
+                .build();
+        samplePlace.setPlaceId(1);
+
+        samplePlaceMedia = PlaceMedia.builder()
+                .place(samplePlace)
+                .path("https://example.com/place.png")
+                .build();
+
+        sampleOpeningDate = OpeningDate.builder()
+                .dayType("매주 일요일 휴무")
+                .startTime("9:00")
+                .endTime("17:00")
+                .place(samplePlace)
+                .build();
+        sampleOpeningDate.setOpeningDateId(1);
+
+        sampleFavorite =  Favorite.builder()
+                .user(sampleUser)
+                .place(samplePlace)
+                .build();
+        sampleFavorite.setFavoriteId(1);
+        sampleFavorite.setCreatedAt(LocalDateTime.now());
+        sampleFavorite.setUpdatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    void testRegisterFavorite_Success() {
+        FavoriteRequestDto requestDto = new FavoriteRequestDto(1);
+
+        when(userRepository.findById(1)).thenReturn(Optional.of(sampleUser));
+        when(favoriteRepository.findByUser_UserIdAndPlace_PlaceId(1, 1)).thenReturn(new ArrayList<>());
+        when(placeRepository.findById(1)).thenReturn(Optional.of(samplePlace));
+        when(placeMediaRepository.findByPlace_PlaceId(1)).thenReturn(Optional.of(samplePlaceMedia));
+        when(openingDateRepository.findByPlace_PlaceId(1)).thenReturn(List.of(sampleOpeningDate));
+
+        FavoriteResponseDto result = favoriteService.registerFavorite(1, requestDto);
+
+        assertNotNull(result);
+        assertEquals(1, result.getPlaceId());
+        assertEquals("Sample Place", result.getName());
+        assertEquals("https://example.com/place.png", result.getPlaceImage());
+
+        verify(favoriteRepository, times(1)).save(any(Favorite.class));
+    }
+
+
+    @Test
+    void testRegisterFavorite_Duplicate() {
+        FavoriteRequestDto requestDto = new FavoriteRequestDto(1);
+
+        when(userRepository.findById(1)).thenReturn(Optional.of(sampleUser));
+        when(favoriteRepository.findByUser_UserIdAndPlace_PlaceId(1, 1)).thenReturn(List.of(sampleFavorite));
+
+        assertThrows(DuplicateFavoriteException.class, () -> favoriteService.registerFavorite(1, requestDto));
+    }
+
+    @Test
+    void testRegisterFavorite_UserNotFound() {
+        FavoriteRequestDto requestDto = new FavoriteRequestDto(1);
+
+        when(userRepository.findById(1)).thenReturn(Optional.empty());
+
+        assertThrows(UserNotFoundException.class, () -> favoriteService.registerFavorite(1, requestDto));
+    }
+
+    @Test
+    void testRegisterFavorite_PlaceNotFound() {
+        FavoriteRequestDto requestDto = new FavoriteRequestDto(1);
+
+        when(userRepository.findById(1)).thenReturn(Optional.of(sampleUser));
+        when(favoriteRepository.findByUser_UserIdAndPlace_PlaceId(1, 1)).thenReturn(Collections.emptyList());
+        when(placeRepository.findById(1)).thenReturn(Optional.empty());
+
+        assertThrows(PlaceNotFoundException.class, () -> favoriteService.registerFavorite(1, requestDto));
+    }
+
+    @Test
+    void testDeleteFavorite_Success() {
+        when(favoriteRepository.existsById(1)).thenReturn(true);
+
+        favoriteService.deleteFavorite(1);
+
+        verify(favoriteRepository, times(1)).deleteById(1);
+    }
+
+    @Test
+    void testDeleteFavorite_FavoriteNotFound() {
+        when(favoriteRepository.existsById(1)).thenReturn(false);
+
+        assertThrows(FavoriteNotFoundException.class, () -> favoriteService.deleteFavorite(1));
+    }
+
+    @Test
+    void testFetchFavoriteList_Success() {
+        LocalDateTime now = LocalDateTime.now();
+        when(favoriteRepository.findCustomFavorites(1, now, 0, 10)).thenReturn(Collections.emptyList());
+
+        List<FavoriteResponseDto> result = favoriteService.fetchFavoriteList(1, now, 0, 10);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(favoriteRepository, times(1)).findCustomFavorites(1, now, 0, 10);
+    }
+}

--- a/src/test/java/com/daengdaeng_eodiga/project/pet/PetServiceTest.java
+++ b/src/test/java/com/daengdaeng_eodiga/project/pet/PetServiceTest.java
@@ -1,0 +1,175 @@
+package com.daengdaeng_eodiga.project.pet;
+
+import com.daengdaeng_eodiga.project.Global.exception.*;
+import com.daengdaeng_eodiga.project.common.service.CommonCodeService;
+import com.daengdaeng_eodiga.project.pet.dto.PetListResponseDto;
+import com.daengdaeng_eodiga.project.pet.dto.PetRegisterDto;
+import com.daengdaeng_eodiga.project.pet.dto.PetUpdateDto;
+import com.daengdaeng_eodiga.project.pet.entity.Pet;
+import com.daengdaeng_eodiga.project.pet.repository.PetRepository;
+import com.daengdaeng_eodiga.project.pet.service.PetService;
+import com.daengdaeng_eodiga.project.user.entity.User;
+import com.daengdaeng_eodiga.project.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PetServiceTest {
+
+    @InjectMocks
+    private PetService petService;
+
+    @Mock
+    private PetRepository petRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CommonCodeService commonCodeService;
+
+    private User sampleUser;
+    private Pet samplePet;
+
+    @BeforeEach
+    void setUp() throws ParseException {
+        MockitoAnnotations.openMocks(this);
+
+        sampleUser = User.builder()
+                .userId(1)
+                .nickname("testUser")
+                .email("user1@example.com")
+                .gender("GND_01")
+                .city("광주")
+                .cityDetail("광산구")
+                .oauthProvider("google")
+                .build();
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        Date birthday = dateFormat.parse("2020-12-24");
+        samplePet = Pet.builder()
+                .image("https://example.com/pet1.png")
+                .size("PET_SIZ_01")
+                .user(sampleUser)
+                .birthday(birthday)
+                .gender("GND_02")
+                .name("Buddy")
+                .neutering(true)
+                .species("PET_TYP_10")
+                .build();
+        samplePet.setPetId(1);
+    }
+
+    @Test
+    void fetchUserPets_ShouldReturnPets() {
+        when(petRepository.findAllByUser(sampleUser)).thenReturn(List.of(samplePet));
+
+        List<Pet> pets = petService.fetchUserPets(sampleUser);
+
+        assertNotNull(pets);
+        assertEquals(1, pets.size());
+        assertEquals("Buddy", pets.get(0).getName());
+
+        verify(petRepository, times(1)).findAllByUser(sampleUser);
+    }
+
+    @Test
+    void registerPet_ShouldSavePet() {
+        PetRegisterDto requestDto = PetRegisterDto.builder()
+                .name("Buddy")
+                .species("PET_TYP_10")
+                .gender("GND_02")
+                .size("PET_SIZ_01")
+                .birthday("2024-01-01")
+                .neutering(false)
+                .build();
+
+        when(userRepository.findById(1)).thenReturn(Optional.of(sampleUser));
+
+        petService.registerPet(1, requestDto);
+
+        verify(commonCodeService, times(1)).isCommonCode("PET_TYP_10");
+        verify(commonCodeService, times(1)).isCommonCode("GND_02");
+        verify(commonCodeService, times(1)).isCommonCode("PET_SIZ_01");
+        verify(petRepository, times(1)).save(any(Pet.class));
+    }
+
+    @Test
+    void fetchUserPetListDto_ShouldReturnPetListResponseDto() {
+        when(userRepository.findById(1)).thenReturn(Optional.of(sampleUser));
+        when(petRepository.findAllByUser(sampleUser)).thenReturn(List.of(samplePet));
+        when(commonCodeService.getCommonCodeName(anyString())).thenReturn("Friendly Name");
+
+        List<PetListResponseDto> result = petService.fetchUserPetListDto(1);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("Buddy", result.get(0).getName());
+
+        verify(petRepository, times(1)).findAllByUser(sampleUser);
+    }
+
+    @Test
+    void deletePet_ShouldDeletePet() {
+        when(userRepository.findById(1)).thenReturn(Optional.of(sampleUser));
+        when(petRepository.findById(1)).thenReturn(Optional.of(samplePet));
+
+        petService.deletePet(1, 1);
+
+        verify(petRepository, times(1)).delete(samplePet);
+    }
+
+    @Test
+    void deletePet_ShouldThrowException_WhenPetNotOwnedByUser() {
+        User anotherUser = User.builder()
+                .userId(2)
+                .nickname("testUser2")
+                .email("user2@example.com")
+                .gender("GND_02")
+                .city("대전")
+                .cityDetail("대덕구")
+                .oauthProvider("google")
+                .build();
+        samplePet.setUser(anotherUser);
+
+        when(userRepository.findById(1)).thenReturn(Optional.of(sampleUser));
+        when(petRepository.findById(1)).thenReturn(Optional.of(samplePet));
+
+        assertThrows(UserUnauthorizedException.class, () -> petService.deletePet(1, 1));
+        verify(petRepository, never()).delete(samplePet);
+    }
+
+    @Test
+    void updatePet_ShouldUpdatePet() {
+        PetUpdateDto updateDto = PetUpdateDto.builder()
+                .name("Updated Buddy")
+                .species("PET_TYP_09")
+                .gender("GND_01")
+                .size("PET_SIZ_02")
+                .birthday("2024-01-01")
+                .neutering(true)
+                .build();
+
+        when(petRepository.findById(1)).thenReturn(Optional.of(samplePet));
+
+        petService.updatePet(1, updateDto);
+
+        verify(commonCodeService, times(1)).isCommonCode("PET_TYP_09");
+        verify(commonCodeService, times(1)).isCommonCode("GND_01");
+        verify(commonCodeService, times(1)).isCommonCode("PET_SIZ_02");
+        verify(petRepository, times(1)).save(samplePet);
+
+        assertEquals("Updated Buddy", samplePet.getName());
+    }
+}

--- a/src/test/java/com/daengdaeng_eodiga/project/place/PlaceServiceTest.java
+++ b/src/test/java/com/daengdaeng_eodiga/project/place/PlaceServiceTest.java
@@ -1,4 +1,4 @@
-package com.daengdaeng_eodiga.project;
+package com.daengdaeng_eodiga.project.place;
 
 
 import com.daengdaeng_eodiga.project.Global.Redis.Repository.RedisLocationRepository;

--- a/src/test/java/com/daengdaeng_eodiga/project/preference/PreferenceServiceTest.java
+++ b/src/test/java/com/daengdaeng_eodiga/project/preference/PreferenceServiceTest.java
@@ -1,0 +1,167 @@
+package com.daengdaeng_eodiga.project.preference;
+
+import com.daengdaeng_eodiga.project.Global.exception.CommonCodeNotFoundException;
+import com.daengdaeng_eodiga.project.Global.exception.DuplicatePreferenceException;
+import com.daengdaeng_eodiga.project.common.entity.CommonCode;
+import com.daengdaeng_eodiga.project.common.entity.GroupCode;
+import com.daengdaeng_eodiga.project.common.repository.CommonCodeRepository;
+import com.daengdaeng_eodiga.project.common.repository.GroupCodeRepository;
+import com.daengdaeng_eodiga.project.preference.dto.PreferenceRequestDto;
+import com.daengdaeng_eodiga.project.preference.dto.PreferenceResponseDto;
+import com.daengdaeng_eodiga.project.preference.entity.Preference;
+import com.daengdaeng_eodiga.project.preference.entity.PreferenceId;
+import com.daengdaeng_eodiga.project.preference.repository.PreferenceRepository;
+import com.daengdaeng_eodiga.project.preference.service.PreferenceService;
+import com.daengdaeng_eodiga.project.user.entity.User;
+import com.daengdaeng_eodiga.project.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PreferenceServiceTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private PreferenceRepository preferenceRepository;
+
+    @Mock
+    private CommonCodeRepository commonCodeRepository;
+
+    @Mock
+    private GroupCodeRepository groupCodeRepository;
+
+    @InjectMocks
+    private PreferenceService preferenceService;
+
+    private User sampleUser;
+    private Preference samplePreference;
+    private CommonCode sampleCommonCode;
+    private GroupCode sampleGroupCode;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        sampleUser = User.builder()
+                .userId(1)
+                .nickname("user1")
+                .email("user1@example.com")
+                .gender("GND_01")
+                .city("광주")
+                .cityDetail("광산구")
+                .oauthProvider("google")
+                .build();
+
+        sampleGroupCode = GroupCode.builder()
+                .groupId("PLACE_TYP")
+                .name("시설종류")
+                .build();
+
+        sampleCommonCode = CommonCode.builder()
+                .codeId("PLACE_TYP_02")
+                .name("카페")
+                .groupCode(sampleGroupCode)
+                .build();
+
+        samplePreference = new Preference();
+        samplePreference.setUser(sampleUser);
+        samplePreference.setPreferenceType("PLACE_TYP");
+        samplePreference.setId(new PreferenceId("PLACE_TYP_02", 1));
+    }
+
+    @Test
+    void testRegisterPreference_Success() {
+        PreferenceRequestDto requestDto = new PreferenceRequestDto("PLACE_TYP", Set.of("PLACE_TYP_02"));
+
+        when(userService.findUser(1)).thenReturn(sampleUser);
+        when(preferenceRepository.findByUser_UserIdAndPreferenceType(1, "PLACE_TYP")).thenReturn(Collections.emptyList());
+        when(commonCodeRepository.findByGroupCode_GroupIdAndCodeIdIn("PLACE_TYP", Set.of("PLACE_TYP_02")))
+                .thenReturn(List.of(sampleCommonCode));
+
+        PreferenceResponseDto result = preferenceService.registerPreference(1, requestDto);
+
+        assertNotNull(result);
+        assertEquals("PLACE_TYP", result.getPreferenceInfo());
+        assertEquals(1, result.getPreferenceTypes().size());
+        assertTrue(result.getPreferenceTypes().contains("PLACE_TYP_02"));
+
+        verify(preferenceRepository, times(1)).saveAll(anySet());
+    }
+
+    @Test
+    void testRegisterPreference_Duplicate() {
+        PreferenceRequestDto requestDto = new PreferenceRequestDto("PLACE_TYP", Set.of("PLACE_TYP_02"));
+
+        when(userService.findUser(1)).thenReturn(sampleUser);
+        when(preferenceRepository.findByUser_UserIdAndPreferenceType(1, "PLACE_TYP"))
+                .thenReturn(List.of(samplePreference));
+
+        assertThrows(DuplicatePreferenceException.class, () -> preferenceService.registerPreference(1, requestDto));
+    }
+
+    @Test
+    void testRegisterPreference_CommonCodeNotFound() {
+        PreferenceRequestDto requestDto = new PreferenceRequestDto("PLACE_TYP", Set.of("INVALID_CODE"));
+
+        when(userService.findUser(1)).thenReturn(sampleUser);
+        when(preferenceRepository.findByUser_UserIdAndPreferenceType(1, "PLACE_TYP")).thenReturn(Collections.emptyList());
+        when(commonCodeRepository.findByGroupCode_GroupIdAndCodeIdIn("PLACE_TYP", Set.of("INVALID_CODE")))
+                .thenReturn(Collections.emptyList());
+
+        assertThrows(CommonCodeNotFoundException.class, () -> preferenceService.registerPreference(1, requestDto));
+    }
+
+    @Test
+    void testUpdatePreference_Success() {
+        PreferenceRequestDto requestDto = new PreferenceRequestDto("PLACE_TYP", Set.of("PLACE_TYP_02"));
+
+        when(userService.findUser(1)).thenReturn(sampleUser);
+        when(commonCodeRepository.findByGroupCode_GroupIdAndCodeIdIn("PLACE_TYP", Set.of("PLACE_TYP_02")))
+                .thenReturn(List.of(sampleCommonCode));
+
+        PreferenceResponseDto result = preferenceService.updatePreference(1, requestDto);
+
+        assertNotNull(result);
+        assertEquals("PLACE_TYP", result.getPreferenceInfo());
+        assertTrue(result.getPreferenceTypes().contains("PLACE_TYP_02"));
+
+        verify(preferenceRepository, times(1)).deleteByUserAndPreferenceType(sampleUser, "PLACE_TYP");
+        verify(preferenceRepository, times(1)).saveAll(anySet());
+    }
+
+    @Test
+    void testFetchPreferences_Success() {
+        when(userService.findUser(1)).thenReturn(sampleUser);
+        when(preferenceRepository.findByUser(sampleUser)).thenReturn(List.of(samplePreference));
+        when(groupCodeRepository.findByGroupId("PLACE_TYP")).thenReturn(Optional.of(sampleGroupCode));
+        when(commonCodeRepository.findByCodeId("PLACE_TYP_02")).thenReturn(Optional.of(sampleCommonCode));
+
+        List<PreferenceResponseDto> result = preferenceService.fetchPreferences(1);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("시설종류", result.get(0).getPreferenceInfo());
+        assertTrue(result.get(0).getPreferenceTypes().contains("카페"));
+
+        verify(preferenceRepository, times(1)).findByUser(sampleUser);
+    }
+
+    @Test
+    void testFetchPreferences_CommonCodeNotFound() {
+        when(userService.findUser(1)).thenReturn(sampleUser);
+        when(preferenceRepository.findByUser(sampleUser)).thenReturn(List.of(samplePreference));
+        when(groupCodeRepository.findByGroupId("PLACE_TYP")).thenReturn(Optional.of(sampleGroupCode));
+        when(commonCodeRepository.findByCodeId("PLACE_TYP_02")).thenReturn(Optional.empty());
+
+        assertThrows(CommonCodeNotFoundException.class, () -> preferenceService.fetchPreferences(1));
+    }
+}

--- a/src/test/java/com/daengdaeng_eodiga/project/story/StoryServiceTest.java
+++ b/src/test/java/com/daengdaeng_eodiga/project/story/StoryServiceTest.java
@@ -1,0 +1,226 @@
+package com.daengdaeng_eodiga.project.story;
+
+import com.daengdaeng_eodiga.project.Global.Redis.Repository.RedisStoryRepository;
+import com.daengdaeng_eodiga.project.Global.exception.*;
+import com.daengdaeng_eodiga.project.pet.entity.Pet;
+import com.daengdaeng_eodiga.project.pet.repository.PetRepository;
+import com.daengdaeng_eodiga.project.region.entity.RegionOwnerLog;
+import com.daengdaeng_eodiga.project.region.repository.RegionOwnerLogRepository;
+import com.daengdaeng_eodiga.project.story.dto.*;
+import com.daengdaeng_eodiga.project.story.entity.Story;
+import com.daengdaeng_eodiga.project.story.entity.StoryView;
+import com.daengdaeng_eodiga.project.story.repository.StoryRepository;
+import com.daengdaeng_eodiga.project.story.repository.StoryViewRepository;
+import com.daengdaeng_eodiga.project.story.service.StoryService;
+import com.daengdaeng_eodiga.project.user.entity.User;
+import com.daengdaeng_eodiga.project.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class StoryServiceTest {
+
+    @Mock
+    private StoryRepository storyRepository;
+
+    @Mock
+    private StoryViewRepository storyViewRepository;
+
+    @Mock
+    private PetRepository petRepository;
+
+    @Mock
+    private RegionOwnerLogRepository regionOwnerLogRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private RedisStoryRepository redisStoryRepository;
+
+    @InjectMocks
+    private StoryService storyService;
+
+    private Story sampleStory;
+    private User sampleUser;
+    private RegionOwnerLog sampleRegionOwnerLog;
+    private Pet samplePet;
+
+    @BeforeEach
+    void setUp() throws ParseException {
+        MockitoAnnotations.openMocks(this);
+
+        sampleUser = User.builder()
+                .userId(1)
+                .nickname("user1")
+                .email("user1@example.com")
+                .gender("GND_01")
+                .city("광주")
+                .cityDetail("광산구")
+                .oauthProvider("google")
+                .build();
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        Date birthday = dateFormat.parse("2020-12-24");
+        samplePet = Pet.builder()
+                .image("https://example.com/pet1.png")
+                .size("PET_SIZ_01")
+                .user(sampleUser)
+                .birthday(birthday)
+                .gender("GND_02")
+                .name("user1Pet")
+                .neutering(true)
+                .species("PET_TYP_10")
+                .build();
+
+        sampleRegionOwnerLog = RegionOwnerLog.builder()
+                .user(sampleUser)
+                .city("광주")
+                .cityDetail("광산구")
+                .count(10)
+                .build();
+
+        sampleStory = Story.builder()
+                .user(sampleUser)
+                .city("광주")
+                .cityDetail("광산구")
+                .path("https://example.com/path/review1.png")
+                .createdAt(LocalDateTime.now())
+                .endAt(LocalDateTime.now().plusHours(24))
+                .build();
+        sampleStory.setStoryId(1);
+    }
+
+    @Test
+    void testRegisterStory_Success() {
+        StoryRequestDto storyRequestDto = new StoryRequestDto("https://example.com/path/review1.png","광주", "광산구");
+        when(storyRepository.countByTodayCreated(anyInt(), any(), any())).thenReturn(0L);
+        List<Object[]> mockResult = new ArrayList<>();
+        mockResult.add(new Object[] {
+                1,
+                sampleUser,
+                "광주",
+                "광산구",
+                10
+        });
+        when(regionOwnerLogRepository.findByUserIdAndCityAndCityDetailForUpload(1, "광주", "광산구")).thenReturn(mockResult);
+        when(userService.findUser(1)).thenReturn(sampleUser);
+        List<Pet> mockResult2 = new ArrayList<>();
+        mockResult2.add(samplePet);
+        when(petRepository.findAllByUser(sampleUser)).thenReturn(mockResult2);
+
+        storyService.registerStory(1, storyRequestDto);
+
+        verify(storyRepository, times(1)).save(any(Story.class));
+        verify(redisStoryRepository, times(1)).saveStory(anyString(), anyString(), anyInt(), anyInt(), any(RedisGroupedUserStoriesDto.class));
+    }
+
+    @Test
+    void testRegisterStory_DailyLimitExceeded() {
+        StoryRequestDto storyRequestDto = new StoryRequestDto("광주", "광산구", "https://example.com/path/review1.png");
+        when(storyRepository.countByTodayCreated(anyInt(), any(), any())).thenReturn(10L);
+
+        assertThrows(DailyStoryUploadLimitException.class, () -> storyService.registerStory(1, storyRequestDto));
+    }
+
+    @Test
+    void testRegisterStory_OwnerHistoryNotFound() {
+        StoryRequestDto storyRequestDto = new StoryRequestDto("광주", "광산구", "/sample/path");
+        when(storyRepository.countByTodayCreated(anyInt(), any(), any())).thenReturn(0L);
+        when(regionOwnerLogRepository.findByUserIdAndCityAndCityDetailForUpload(anyInt(), anyString(), anyString())).thenReturn(Collections.emptyList());
+
+        assertThrows(OwnerHistoryNotFoundException.class, () -> storyService.registerStory(1, storyRequestDto));
+    }
+
+    @Test
+    void testFetchGroupedUserStories_Success() {
+        List<Object[]> mockResult = new ArrayList<>();
+        mockResult.add(new Object[] {
+                1,
+                "user1",
+                "광주",
+                "광산구",
+                "https://example.com/pet1.png",
+                "unviewed"
+        });
+        when(storyRepository.findMainPriorityStories(1)).thenReturn(mockResult);
+
+        List<GroupedUserStoriesDto> result = storyService.fetchGroupedUserStories(1);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("user1", result.get(0).getNickname());
+        verify(storyRepository, times(1)).findMainPriorityStories(1);
+    }
+
+    @Test
+    void testFetchMyStories_Success() {
+        List<Object[]> mockResult = new ArrayList<>();
+        mockResult.add(new Object[] {
+                "user1",
+                1,
+                "광주",
+                "광산구",
+                "https://example.com/path/review1.png"
+        });
+        when(storyRepository.findMyActiveStoriesByUserId(1)).thenReturn(mockResult);
+
+        MyStoriesDto result = storyService.fetchMyStories(1);
+
+        assertNotNull(result);
+        assertEquals("user1", result.getNickname());
+        assertEquals(1, result.getContent().size());
+        verify(storyRepository, times(1)).findMyActiveStoriesByUserId(1);
+    }
+
+    @Test
+    void testFetchMyStories_NotFound() {
+        when(storyRepository.findMyActiveStoriesByUserId(1)).thenReturn(Collections.emptyList());
+
+        assertThrows(UserStoryNotFoundException.class, () -> storyService.fetchMyStories(1));
+    }
+
+    @Test
+    void testViewStory_Success() {
+        when(storyRepository.findByStoryId(1)).thenReturn(Optional.of(sampleStory));
+        when(userService.findUser(1)).thenReturn(sampleUser);
+
+        storyService.viewStory(1, 1);
+
+        verify(storyViewRepository, times(1)).save(any(StoryView.class));
+    }
+
+    @Test
+    void testViewStory_StoryNotFound() {
+        when(storyRepository.findByStoryId(1)).thenReturn(Optional.empty());
+
+        assertThrows(UserStoryNotFoundException.class, () -> storyService.viewStory(1, 1));
+    }
+
+    @Test
+    void testDeleteStory_Success() {
+        when(storyRepository.findByStoryId(1)).thenReturn(Optional.of(sampleStory));
+
+        storyService.deleteStory(1);
+
+        verify(storyRepository, times(1)).deleteById(1);
+        verify(redisStoryRepository, times(1)).deleteStory(anyString(), anyString(), anyInt(), anyInt());
+    }
+
+    @Test
+    void testDeleteStory_StoryNotFound() {
+        when(storyRepository.findByStoryId(1)).thenReturn(Optional.empty());
+
+        assertThrows(UserStoryNotFoundException.class, () -> storyService.deleteStory(1));
+    }
+}


### PR DESCRIPTION
# 📄 PR 변경사항
- 스토리 등록 시, 레디스에도 등록됨 / 스토리 삭제 시, 레디스에서도 삭제됨
- 비회원유저의 스토리 조회 시,
  > 캐싱된 데이터가 있다면 해당 데이터를 정렬 및 그룹화하여 반환
  > 캐싱된 데이터가 없다면 DB로부터 스토리를 불러와서 레디스에  모두 등록 후 해당 데이터 정렬 및 그룹화하여 반환
- story table에서 데이터들을 레디스로 옮기는 과정에서 n+1 문제 발생
  > 스토리 10개를 조회할때, 각 스토리에 연관된 유저와 반려동물을 조회하는 과정에서 각 10개의 select쿼리가 발생하여
총 21개의 쿼리가 발생함

  > **조인해서 pet과 user 엔티티를 조회까지 해야했기 때문에 join fetch를 사용함**
  > **그결과 1개의 쿼리로 줄어듦**
  - join이 아닌 join fetch를 사용한 이유
  

     > 1. join은 조건에만 사용됨. 또한, n+1문제가 여전히 발생할수있음.
     > 2. 엔티티를 조회까지 해야하므로 즉시로딩인 join fetch를 선택함.

# 🖌️ 구체적인 구현 내용
<!--  어떤 점을 고려하여 구현하였는지, 어떤 예외를 던지는지 등의 내용을 알려주세요! -->
- 

# ✨개선 사항 및 참고 사항
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 


# 💯 테스트
<!--  포스트맨 캡쳐 또는 어떤 테스트 코드를 작성하였는지 말씀해주세요. -->
- 

# 확인
- [x] 주석 및 print를 제거하셨나요?
- [x] javaDoc을 작성하셨나요?
- [x] merge할 브랜치와 로컬에서 merge 하셨나요?
- [x] 더 수정할 작업은 없는지 확인하셨나요?

